### PR TITLE
Add default correlation and zone controls

### DIFF
--- a/src/backend/schemas/simulation_config_schema.json
+++ b/src/backend/schemas/simulation_config_schema.json
@@ -155,6 +155,13 @@
       "minimum": 0,
       "default": 1.5
     },
+    "exit_year_max_std_dev": {
+      "type": "number",
+      "description": "Maximum multiple of std dev for exit year distribution",
+      "minimum": 1,
+      "maximum": 5,
+      "default": 3
+    },
     "min_holding_period": {
       "type": "number",
       "description": "Minimum holding period for a loan before exit (in years)",
@@ -172,6 +179,32 @@
       "minimum": 0,
       "maximum": 1,
       "default": 0.3
+    },
+    "zone_rebalancing_enabled": {
+      "type": "boolean",
+      "description": "Whether to enable zone rebalancing",
+      "default": true
+    },
+    "rebalancing_strength": {
+      "type": "number",
+      "description": "How strongly to rebalance zone allocations (0-1)",
+      "minimum": 0,
+      "maximum": 1,
+      "default": 0.5
+    },
+    "zone_drift_threshold": {
+      "type": "number",
+      "description": "Maximum allowed drift from target allocation",
+      "minimum": 0,
+      "maximum": 0.5,
+      "default": 0.1
+    },
+    "zone_allocation_precision": {
+      "type": "number",
+      "description": "How precisely to match target zone allocations (0-1)",
+      "minimum": 0,
+      "maximum": 1,
+      "default": 0.8
     },
     "zone_allocations": {
       "type": "object",
@@ -347,6 +380,32 @@
       "minimum": -1,
       "maximum": 1,
       "default": 0.3
+    },
+    "default_correlation": {
+      "type": "object",
+      "description": "Correlation of default timing across loans",
+      "properties": {
+        "same_zone": {
+          "type": "number",
+          "description": "Correlation between defaults in the same zone",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.3
+        },
+        "cross_zone": {
+          "type": "number",
+          "description": "Correlation between defaults across different zones",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.1
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable default correlation",
+          "default": true
+        }
+      },
+      "additionalProperties": false
     },
     "monte_carlo_enabled": {
       "type": "boolean",


### PR DESCRIPTION
## Summary
- update `simulation_config_schema.json` with zone rebalancing controls
- add default correlation options and exit year max deviation

## Testing
- `python -m pytest -V` *(fails: No module named pytest)*