### PR TITLE
Replace debug print statements with logging

### DIFF
--- a/src/backend/calculations/cash_flows.py
+++ b/src/backend/calculations/cash_flows.py
@@ -579,8 +579,6 @@ def project_cash_flows(
     market_conditions_by_year: Optional[Dict[int, Dict[str, Any]]] = None
 ) -> Dict[int, Dict[str, Any]]:
     _validate_params(params)
-    import logging
-    logger = logging.getLogger(__name__)
     logger.info("Starting yearly cash flow projection.")
     fund_term = int(params.get('fund_term', 10))
 
@@ -801,13 +799,12 @@ def project_cash_flows(
 
     # DEBUG: Log LP cash flows for verification
     try:
-        logger = logging.getLogger(__name__)
         lp_net = [float(cash_flows[year]['lp_net_cash_flow']) for year in sorted(cash_flows.keys())]
         lp_cum = [float(cash_flows[year]['lp_cumulative_cash_flow']) for year in sorted(cash_flows.keys())]
         logger.info(f"LP net cash flow array: {lp_net}")
         logger.info(f"LP cumulative cash flow array: {lp_cum}")
     except Exception as e:
-        print(f"[DEBUG] Could not log LP cash flows: {e}")
+        logger.debug(f"[DEBUG] Could not log LP cash flows: {e}")
 
     return cash_flows
 
@@ -1110,8 +1107,6 @@ def project_cash_flows_monthly(
     market_conditions_by_month: Optional[Dict[int, Dict[str, Any]]] = None
 ) -> Dict[int, Dict[str, Any]]:
     _validate_params(params)
-    import logging
-    logger = logging.getLogger(__name__)
     logger.info("Starting monthly cash flow projection.")
     fund_term = int(params.get('fund_term', 10))
     total_months = fund_term * 12
@@ -1235,7 +1230,7 @@ def project_cash_flows_monthly(
             )
             cash_flows[month]['reinvestment'] = -reinvestment_amount
             # DEBUG PRINTS
-            print(f"[DEBUG] Month {month}: Exited Loans: {len(exited_loans)}, Reinvestment Amount: {reinvestment_amount}, Reinvestment Period (months): {int(params.get('reinvestment_period', 5)) * 12}")
+            logger.debug(f"[DEBUG] Month {month}: Exited Loans: {len(exited_loans)}, Reinvestment Amount: {reinvestment_amount}, Reinvestment Period (months): {int(params.get('reinvestment_period', 5)) * 12}")
     cumulative = Decimal('0')
     lp_cumulative = Decimal('0')
     idle_cash_rate = Decimal(str(params.get('idle_cash_rate', '0')))
@@ -1281,13 +1276,12 @@ def project_cash_flows_monthly(
         cash_flows[month]['cash_balance'] = cash_balance
         prev_cash_balance = cash_balance
     try:
-        logger = logging.getLogger(__name__)
         lp_net = [float(cash_flows[month]['lp_net_cash_flow']) for month in sorted(cash_flows.keys())]
         lp_cum = [float(cash_flows[month]['lp_cumulative_cash_flow']) for month in sorted(cash_flows.keys())]
         logger.info(f"[Monthly] LP net cash flow array: {lp_net}")
         logger.info(f"[Monthly] LP cumulative cash flow array: {lp_cum}")
     except Exception as e:
-        print(f"[DEBUG] Could not log monthly LP cash flows: {e}")
+        logger.debug(f"[DEBUG] Could not log monthly LP cash flows: {e}")
     return cash_flows
 
 def aggregate_monthly_to_yearly(monthly_data: Dict[int, Dict[str, Any]]) -> Dict[int, Dict[str, Any]]:

--- a/src/backend/calculations/performance.py
+++ b/src/backend/calculations/performance.py
@@ -20,6 +20,8 @@ from typing import Dict, List, Tuple, Any, Optional
 from datetime import datetime, timedelta
 import logging
 
+logger = logging.getLogger(__name__)
+
 # Constants for performance calculations
 DECIMAL_ZERO = Decimal('0')
 DECIMAL_ONE = Decimal('1')
@@ -69,7 +71,7 @@ def calculate_irr_fallback(cash_flows_array):
         try:
             return sum(cf / ((1 + rate) ** t) for t, cf in enumerate(cash_flows_array))
         except ZeroDivisionError:
-            print(f"[IRR Fallback] ZeroDivisionError for rate={rate}, cash_flows_array={cash_flows_array}")
+            logger.debug(f"[IRR Fallback] ZeroDivisionError for rate={rate}, cash_flows_array={cash_flows_array}")
             return float('inf') if rate > -1 else float('-inf')
 
     # Use bisection method with a wide range
@@ -81,7 +83,7 @@ def calculate_irr_fallback(cash_flows_array):
         low_npv = npv(low_rate)
         high_npv = npv(high_rate)
     except ZeroDivisionError:
-        print(f"[IRR Fallback] ZeroDivisionError in initial NPV calculation. cash_flows_array={cash_flows_array}")
+        logger.debug(f"[IRR Fallback] ZeroDivisionError in initial NPV calculation. cash_flows_array={cash_flows_array}")
         return 0.0
 
     if low_npv * high_npv > 0:
@@ -93,7 +95,7 @@ def calculate_irr_fallback(cash_flows_array):
             try:
                 npvs.append(npv(r))
             except ZeroDivisionError:
-                print(f"[IRR Fallback] ZeroDivisionError for rate={r}, cash_flows_array={cash_flows_array}")
+                logger.debug(f"[IRR Fallback] ZeroDivisionError for rate={r}, cash_flows_array={cash_flows_array}")
                 npvs.append(float('inf'))
         # Find where NPV changes sign
         for i in range(len(rates) - 1):
@@ -113,7 +115,7 @@ def calculate_irr_fallback(cash_flows_array):
         try:
             mid_npv = npv(mid_rate)
         except ZeroDivisionError:
-            print(f"[IRR Fallback] ZeroDivisionError for mid_rate={mid_rate}, cash_flows_array={cash_flows_array}")
+            logger.debug(f"[IRR Fallback] ZeroDivisionError for mid_rate={mid_rate}, cash_flows_array={cash_flows_array}")
             return 0.0
 
         if abs(mid_npv) < 1e-10:  # Very close to zero
@@ -122,7 +124,7 @@ def calculate_irr_fallback(cash_flows_array):
         try:
             low_npv_val = npv(low_rate)
         except ZeroDivisionError:
-            print(f"[IRR Fallback] ZeroDivisionError for low_rate={low_rate}, cash_flows_array={cash_flows_array}")
+            logger.debug(f"[IRR Fallback] ZeroDivisionError for low_rate={low_rate}, cash_flows_array={cash_flows_array}")
             return 0.0
 
         if mid_npv * low_npv_val < 0:
@@ -161,13 +163,13 @@ def pretty_print_cash_flows(cf_dict, periods_per_year=12, max_periods=36):
     """
     Pretty print the cash flows for the first N periods (default: 3 years if monthly).
     """
-    print("\n--- Pretty Cash Flow Table (first 3 years) ---")
-    print(f"{'Month':>5} | {'Net Cash Flow':>15} | {'Cumulative':>15} | {'Capital Calls':>12} | {'Exits':>8} | {'Reinvest':>9}")
-    print("-" * 70)
+    logger.debug("\n--- Pretty Cash Flow Table (first 3 years) ---")
+    logger.debug(f"{'Month':>5} | {'Net Cash Flow':>15} | {'Cumulative':>15} | {'Capital Calls':>12} | {'Exits':>8} | {'Reinvest':>9}")
+    logger.debug("-" * 70)
     for period in range(1, max_periods + 1):
         cf = cf_dict.get(period, {})
-        print(f"{period:5} | {cf.get('net_cash_flow', 0):15,.2f} | {cf.get('cumulative_cash_flow', 0):15,.2f} | {cf.get('capital_calls', 0):12,.2f} | {cf.get('exit_proceeds', 0):8,.2f} | {cf.get('reinvestment', 0):9,.2f}")
-    print("-" * 70)
+        logger.debug(f"{period:5} | {cf.get('net_cash_flow', 0):15,.2f} | {cf.get('cumulative_cash_flow', 0):15,.2f} | {cf.get('capital_calls', 0):12,.2f} | {cf.get('exit_proceeds', 0):8,.2f} | {cf.get('reinvestment', 0):9,.2f}")
+    logger.debug("-" * 70)
 
 
 def calculate_irr(
@@ -187,7 +189,6 @@ def calculate_irr(
     Returns:
         Dictionary with IRR results including both calculation methods
     """
-    logger = logging.getLogger(__name__)
     _validate_cash_flows(cash_flows)
     _validate_capital_contributions(capital_contributions)
     # Extract cash flow values and periods (support both years and months)
@@ -841,7 +842,6 @@ def calculate_gross_cash_flows(cash_flows: Dict[int, Dict[str, Decimal]]) -> Dic
     Returns:
         Dictionary with gross cash flows
     """
-    logger = logging.getLogger(__name__)
     logger.info("Calculating gross cash flows (before fees and carried interest)")
 
     # Create a deep copy of the cash flows to avoid modifying the original
@@ -906,7 +906,6 @@ def calculate_gross_performance_metrics(cash_flows: Dict[int, Dict[str, Decimal]
     Returns:
         Dictionary with gross performance metrics
     """
-    logger = logging.getLogger(__name__)
     logger.info("Calculating gross performance metrics (before fees and carried interest)")
 
     # Calculate gross cash flows
@@ -1099,7 +1098,6 @@ def calculate_irr_by_year(cash_flows: Dict[int, Dict[str, Decimal]],
     Returns:
         Dictionary with IRR values for each year
     """
-    logger = logging.getLogger(__name__)
     logger.info("Calculating time-based IRR (IRR by year)")
 
     # Extract cash flow values and years
@@ -1313,7 +1311,6 @@ def calculate_performance_metrics(cash_flows: Dict[int, Dict[str, Decimal]],
     Returns:
         Dictionary with all performance metrics
     """
-    logger = logging.getLogger(__name__)
     logger.info("Calculating comprehensive performance metrics")
 
     # Calculate Fund IRR (Net IRR)


### PR DESCRIPTION
## Summary
- switch debug prints in `loan_lifecycle`, `cash_flows` and `performance` to `logger.debug`
- ensure each module defines `logger = logging.getLogger(__name__)`
- remove redundant local logger creation and imports

## Testing
- `pytest -q` *(fails: `pytest` command not found)*