### PR TITLE
Implement zone rebalancing in lifecycle

### DIFF
--- a/src/backend/calculations/loan_lifecycle.py
+++ b/src/backend/calculations/loan_lifecycle.py
@@ -19,6 +19,7 @@ import uuid
 
 from models_pkg import Fund, Loan, Portfolio
 from utils import decimal_truncated_normal, generate_zone_allocation
+from .loan_lifecycle_enhanced import maintain_zone_balance
 
 # --- Parameterized Defaults ---
 MIN_LOAN_SIZE = Decimal('10000')
@@ -403,7 +404,9 @@ def process_year_enhanced(
     active_loans: List[Loan],
     current_year: int,
     fund: Fund,
-    market_conditions: Optional[Dict[str, Any]] = None
+    market_conditions: Optional[Dict[str, Any]] = None,
+    rebalancing_strength: float = 1.0,
+    zone_rebalancing_enabled: bool = True,
 ) -> Tuple[List[Loan], List[Loan], List[Loan], Dict[str, Any]]:
     """
     Process loans for a given year with enhanced features including market conditions.
@@ -413,6 +416,8 @@ def process_year_enhanced(
         current_year: Current year in the simulation
         fund: Fund instance with configuration parameters
         market_conditions: Optional market conditions for this year
+        rebalancing_strength: How strongly to rebalance zone allocations
+        zone_rebalancing_enabled: Whether zone rebalancing is enabled
 
     Returns:
         Tuple of (active_loans, exited_loans, new_reinvestments, year_metrics)
@@ -521,12 +526,22 @@ def process_year_enhanced(
                 reinvestment_params['zone_allocations'] = zone_allocations
 
             # Generate new loans with adjusted parameters
-            new_reinvestments = generate_reinvestment_loans_enhanced(
-                reinvestment_amount,
-                current_year,
-                fund,
-                reinvestment_params
-            )
+            if zone_rebalancing_enabled:
+                new_reinvestments = maintain_zone_balance(
+                    still_active_loans,
+                    reinvestment_amount,
+                    fund.zone_allocations,
+                    current_year,
+                    fund,
+                    rebalancing_strength,
+                )
+            else:
+                new_reinvestments = generate_reinvestment_loans_enhanced(
+                    reinvestment_amount,
+                    current_year,
+                    fund,
+                    reinvestment_params,
+                )
 
     # Combine still active loans and new reinvestments
     updated_active_loans = still_active_loans + new_reinvestments
@@ -751,7 +766,9 @@ def calculate_year_metrics_enhanced(
 def model_portfolio_evolution_enhanced(
     initial_loans: List[Loan],
     fund: Fund,
-    market_conditions: Optional[Dict[str, Dict[str, Any]]] = None
+    market_conditions: Optional[Dict[str, Dict[str, Any]]] = None,
+    rebalancing_strength: float = 1.0,
+    zone_rebalancing_enabled: bool = True,
 ) -> Dict[int, Dict[str, Any]]:
     """
     Enhanced model of portfolio evolution that incorporates market conditions.
@@ -760,6 +777,8 @@ def model_portfolio_evolution_enhanced(
         initial_loans: List of initial loans
         fund: Fund instance with configuration parameters
         market_conditions: Optional dictionary mapping years to market conditions
+        rebalancing_strength: How strongly to rebalance zone allocations
+        zone_rebalancing_enabled: Whether zone rebalancing is enabled
 
     Returns:
         Dictionary mapping years to portfolio state
@@ -835,7 +854,9 @@ def model_portfolio_evolution_enhanced(
             yearly_portfolio[year-1]['active_loans'],
             year,
             fund,
-            year_market_conditions
+            year_market_conditions,
+            rebalancing_strength,
+            zone_rebalancing_enabled,
         )
 
         # Store portfolio state for this year
@@ -1047,7 +1068,9 @@ def model_portfolio_evolution_granular(
     initial_loans: List[Loan],
     fund: Fund,
     market_conditions: Optional[Dict[int, Any]] = None,
-    config: Optional[dict] = None
+    config: Optional[dict] = None,
+    rebalancing_strength: float = 1.0,
+    zone_rebalancing_enabled: bool = True,
 ) -> Dict[int, Dict[str, Any]]:
     """
     @backend
@@ -1057,6 +1080,8 @@ def model_portfolio_evolution_granular(
         fund: Fund instance with configuration parameters (may or may not include 'time_granularity')
         market_conditions: Optional dictionary mapping periods to market conditions
         config: Optional original config dict to use as fallback for time_granularity
+        rebalancing_strength: Strength of zone rebalancing if enabled
+        zone_rebalancing_enabled: Whether zone rebalancing is enabled
     Returns:
         Dictionary mapping periods (years or months) to portfolio state
     """
@@ -1086,4 +1111,10 @@ def model_portfolio_evolution_granular(
         return model_portfolio_evolution_monthly(initial_loans, fund, market_conditions)
     else:
         logger.info("Using yearly granularity for portfolio evolution")
-        return model_portfolio_evolution_enhanced(initial_loans, fund, market_conditions)
+        return model_portfolio_evolution_enhanced(
+            initial_loans,
+            fund,
+            market_conditions,
+            rebalancing_strength,
+            zone_rebalancing_enabled,
+        )

--- a/src/backend/calculations/simulation_controller.py
+++ b/src/backend/calculations/simulation_controller.py
@@ -134,6 +134,10 @@ class SimulationConfig(TypedDict, total=False):
     aggregate_gp_economics: bool
     deployment_monthly_granularity: bool
     time_granularity: str
+    zone_rebalancing_enabled: bool
+    rebalancing_strength: float
+    zone_drift_threshold: float
+    zone_allocation_precision: float
     # ... add other config keys as needed ...
 
 class SimulationResults(TypedDict, total=False):
@@ -266,7 +270,11 @@ class SimulationController:
             'aggregate_gp_economics': True,
             'monte_carlo_parameters': {},
             'deployment_monthly_granularity': False,
-            'time_granularity': 'yearly'
+            'time_granularity': 'yearly',
+            'zone_rebalancing_enabled': True,
+            'rebalancing_strength': 0.5,
+            'zone_drift_threshold': 0.1,
+            'zone_allocation_precision': 0.8,
         }
 
         for key, value in defaults.items():
@@ -572,7 +580,9 @@ class SimulationController:
                 portfolio.loans if hasattr(portfolio, 'loans') else [],
                 fund,
                 market_conditions,
-                self.config
+                self.config,
+                self.config.get('rebalancing_strength', 1.0),
+                self.config.get('zone_rebalancing_enabled', True),
             )
             granularity = self.config.get('time_granularity', 'yearly')
             if granularity == 'monthly':


### PR DESCRIPTION
## Summary
- pass zone rebalancing parameters into the loan lifecycle
- allow SimulationController to forward zone rebalancing options
- call `maintain_zone_balance` when zone rebalancing is enabled

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*