### PR TITLE
Update simulation config schema with new parameters

### DIFF
--- a/src/backend/schemas/simulation_config_schema.json
+++ b/src/backend/schemas/simulation_config_schema.json
@@ -155,6 +155,13 @@
       "minimum": 0,
       "default": 1.5
     },
+    "exit_year_max_std_dev": {
+      "type": "number",
+      "description": "Maximum allowed multiple of exit_year_std_dev",
+      "minimum": 1,
+      "maximum": 5,
+      "default": 3
+    },
     "min_holding_period": {
       "type": "number",
       "description": "Minimum holding period for a loan before exit (in years)",
@@ -200,6 +207,32 @@
         }
       },
       "additionalProperties": false
+    },
+    "zone_rebalancing_enabled": {
+      "type": "boolean",
+      "description": "Whether to enable zone rebalancing",
+      "default": true
+    },
+    "rebalancing_strength": {
+      "type": "number",
+      "description": "How strongly to rebalance zone allocations (0-1)",
+      "minimum": 0,
+      "maximum": 1,
+      "default": 0.5
+    },
+    "zone_drift_threshold": {
+      "type": "number",
+      "description": "Maximum allowed drift from target allocation",
+      "minimum": 0,
+      "maximum": 0.5,
+      "default": 0.1
+    },
+    "zone_allocation_precision": {
+      "type": "number",
+      "description": "How precisely to match target zone allocations (0-1)",
+      "minimum": 0,
+      "maximum": 1,
+      "default": 0.8
     },
     "appreciation_rates": {
       "type": "object",
@@ -347,6 +380,26 @@
       "minimum": -1,
       "maximum": 1,
       "default": 0.3
+    },
+    "default_correlation": {
+      "type": "object",
+      "description": "Correlation between defaults across loans",
+      "properties": {
+        "same_zone": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.3
+        },
+        "cross_zone": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.1
+        },
+        "enabled": { "type": "boolean", "default": true }
+      },
+      "additionalProperties": false
     },
     "monte_carlo_enabled": {
       "type": "boolean",


### PR DESCRIPTION
## Summary
- add `default_correlation` object
- support zone rebalancing fields
- include `exit_year_max_std_dev` parameter

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*