### PR TITLE
Add advanced correlation and rebalancing params

### DIFF
--- a/src/frontend/src/components/wizard/steps/advanced-step.tsx
+++ b/src/frontend/src/components/wizard/steps/advanced-step.tsx
@@ -63,6 +63,99 @@ export function AdvancedStep() {
         </div>
       </FormSection>
 
+      <FormSection
+        title="Default Correlation"
+        description="Set correlation assumptions for loan defaults"
+        defaultExpanded={false}
+      >
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <ParameterField
+            name="default_correlation.enabled"
+            label="Enable Default Correlation"
+            type="switch"
+            defaultValue={true}
+          />
+          <ParameterField
+            name="default_correlation.same_zone"
+            label="Same Zone Correlation"
+            type="percentage"
+            min={0}
+            max={1}
+            step={0.01}
+            defaultValue={0.3}
+          />
+          <ParameterField
+            name="default_correlation.cross_zone"
+            label="Cross Zone Correlation"
+            type="percentage"
+            min={0}
+            max={1}
+            step={0.01}
+            defaultValue={0.1}
+          />
+        </div>
+      </FormSection>
+
+      <FormSection
+        title="Zone Rebalancing"
+        description="Control automatic rebalancing of zone allocations"
+        defaultExpanded={false}
+      >
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <ParameterField
+            name="zone_rebalancing_enabled"
+            label="Enable Zone Rebalancing"
+            type="switch"
+            defaultValue={true}
+          />
+          <ParameterField
+            name="rebalancing_strength"
+            label="Rebalancing Strength"
+            type="percentage"
+            min={0}
+            max={1}
+            step={0.01}
+            defaultValue={0.5}
+          />
+          <ParameterField
+            name="zone_drift_threshold"
+            label="Zone Drift Threshold"
+            type="percentage"
+            min={0}
+            max={0.5}
+            step={0.01}
+            defaultValue={0.1}
+          />
+          <ParameterField
+            name="zone_allocation_precision"
+            label="Zone Allocation Precision"
+            type="percentage"
+            min={0}
+            max={1}
+            step={0.01}
+            defaultValue={0.8}
+          />
+        </div>
+      </FormSection>
+
+      <FormSection
+        title="Lifecycle Timing"
+        description="Advanced exit timing parameters"
+        defaultExpanded={false}
+      >
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <ParameterField
+            name="exit_year_max_std_dev"
+            label="Exit Year Max Std Dev Multiplier"
+            type="number"
+            min={1}
+            max={5}
+            step={0.1}
+            defaultValue={3}
+          />
+        </div>
+      </FormSection>
+
       {/* Leverage Capital Structure ------------------------------------------------*/}
       <FormSection
         title="Leverage – Capital Structure"

--- a/src/frontend/src/schemas/simulation-schema.ts
+++ b/src/frontend/src/schemas/simulation-schema.ts
@@ -82,6 +82,24 @@ export const simulationSchema = z.object({
   report_config: z.record(z.string(), z.any()).optional(),
   stress_config: z.record(z.string(), z.any()).optional(),
   gp_entity: z.record(z.string(), z.any()).optional(),
+
+  // Default Correlation
+  default_correlation: z
+    .object({
+      enabled: z.boolean().default(true),
+      same_zone: z.number().min(0).max(1).default(0.3),
+      cross_zone: z.number().min(0).max(1).default(0.1),
+    })
+    .default({ enabled: true, same_zone: 0.3, cross_zone: 0.1 }),
+
+  // Zone Rebalancing
+  zone_rebalancing_enabled: z.boolean().default(true),
+  rebalancing_strength: z.number().min(0).max(1).default(0.5),
+  zone_drift_threshold: z.number().min(0).max(0.5).default(0.1),
+  zone_allocation_precision: z.number().min(0).max(1).default(0.8),
+
+  // Lifecycle Timing
+  exit_year_max_std_dev: z.number().min(1).max(5).default(3),
 });
 
 // Define the type based on the schema
@@ -154,6 +172,22 @@ export const defaultSimulationConfig: SimulationConfig = {
   generate_reports: true,
   gp_entity_enabled: false,
   aggregate_gp_economics: true,
+
+  // Default Correlation
+  default_correlation: {
+    enabled: true,
+    same_zone: 0.3,
+    cross_zone: 0.1,
+  },
+
+  // Zone Rebalancing
+  zone_rebalancing_enabled: true,
+  rebalancing_strength: 0.5,
+  zone_drift_threshold: 0.1,
+  zone_allocation_precision: 0.8,
+
+  // Lifecycle Timing
+  exit_year_max_std_dev: 3,
 };
 
 // Define the wizard steps
@@ -222,10 +256,25 @@ export const wizardSteps = [
     title: 'Advanced',
     description: 'Configure advanced analytics and reporting',
     fields: [
-      'monte_carlo_enabled', 'num_simulations', 'variation_factor',
-      'monte_carlo_seed', 'optimization_enabled', 'stress_testing_enabled',
-      'external_data_enabled', 'generate_reports', 'gp_entity_enabled',
-      'aggregate_gp_economics', 'report_config', 'stress_config', 'gp_entity',
+      'monte_carlo_enabled',
+      'num_simulations',
+      'variation_factor',
+      'monte_carlo_seed',
+      'optimization_enabled',
+      'stress_testing_enabled',
+      'external_data_enabled',
+      'generate_reports',
+      'gp_entity_enabled',
+      'aggregate_gp_economics',
+      'default_correlation',
+      'zone_rebalancing_enabled',
+      'rebalancing_strength',
+      'zone_drift_threshold',
+      'zone_allocation_precision',
+      'exit_year_max_std_dev',
+      'report_config',
+      'stress_config',
+      'gp_entity',
     ],
   },
   {


### PR DESCRIPTION
## Summary
- add advanced risk parameters to simulation schema
- expose new parameters in the Advanced wizard step

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `pytest -k headless_backend_full -q` *(fails: command not found)*