### PR TITLE
Add leverage_metrics to simulation results

### DIFF
--- a/src/backend/api/leverage_api.py
+++ b/src/backend/api/leverage_api.py
@@ -37,4 +37,4 @@ def leverage_metrics(simulation_id: str):
     sim = _get_results(simulation_id)  # to be implemented
     if not sim:
         raise HTTPException(status_code=404, detail="Simulation not found")
-    return sim.get('leverage', {}) 
+    return sim.get('leverage_metrics', {})

--- a/src/backend/calculations/leverage_engine.py
+++ b/src/backend/calculations/leverage_engine.py
@@ -12,7 +12,7 @@ Design goals for v0:
     – `leverage_metrics` summary (avg_ratio, max_drawn, total_int)
 
 Downstream consumers:
-• `SimulationController` stores both objects under results['leverage'].
+• `SimulationController` stores leverage metrics under results['leverage_metrics'].
 • `CashFlows` unchanged – we tack the interest line item onto cash_flows
   inside this engine to avoid circular imports.
 """

--- a/src/backend/calculations/simulation_controller.py
+++ b/src/backend/calculations/simulation_controller.py
@@ -147,6 +147,7 @@ class SimulationResults(TypedDict, total=False):
     performance_metrics: dict
     gp_entity_economics: dict
     monte_carlo_results: dict
+    leverage_metrics: dict
     optimization_results: dict
     stress_test_results: dict
     reports: dict
@@ -783,7 +784,7 @@ class SimulationController:
                         cash_flows['net_cash_flow'][idx] -= interest
                         cash_flows['distributions'][idx] -= interest
 
-                self.results['leverage'] = lev_outputs['metrics']
+                self.results['leverage_metrics'] = lev_outputs['metrics']
             except Exception as lev_err:
                 logger.warning(f"Leverage module skipped: {lev_err}")
             logger.info("Cash flow calculation completed")

--- a/src/backend/openapi.yaml
+++ b/src/backend/openapi.yaml
@@ -1239,6 +1239,8 @@ components:
         monte_carlo_results:
           type: object
           description: Monte Carlo simulation results
+        leverage_metrics:
+          $ref: '#/components/schemas/LeverageMetrics'
         bootstrap_results:
           $ref: '#/components/schemas/BootstrapResults'
         grid_stress_results:

--- a/src/frontend/src/api/models/SimulationResults.ts
+++ b/src/frontend/src/api/models/SimulationResults.ts
@@ -8,6 +8,7 @@ import type { PerformanceMetrics } from './PerformanceMetrics';
 import type { PortfolioEvolution } from './PortfolioEvolution';
 import type { SimulationConfig } from './SimulationConfig';
 import type { VintageVarResults } from './VintageVarResults';
+import type { LeverageMetrics } from './LeverageMetrics';
 /**
  * Results of a simulation.
  */
@@ -82,6 +83,7 @@ export type SimulationResults = {
      * Monte Carlo simulation results
      */
     monte_carlo_results?: Record<string, any>;
+    leverage_metrics?: LeverageMetrics;
     bootstrap_results?: BootstrapResults;
     grid_stress_results?: GridStressResults;
     vintage_var?: VintageVarResults;


### PR DESCRIPTION
## Summary
- include `leverage_metrics` in the API specification
- store leverage metrics in `SimulationController`
- expose leverage metrics via `/api/leverage/metrics`
- update SDK model for `SimulationResults`

## Testing
- `./generate-sdk.sh` *(fails: connect EHOSTUNREACH)*
- `python -m pytest -q` *(fails: No module named pytest)*