### PR TITLE
Enable zone rebalancing controls

### DIFF
--- a/src/backend/calculations/simulation_controller.py
+++ b/src/backend/calculations/simulation_controller.py
@@ -266,7 +266,11 @@ class SimulationController:
             'aggregate_gp_economics': True,
             'monte_carlo_parameters': {},
             'deployment_monthly_granularity': False,
-            'time_granularity': 'yearly'
+            'time_granularity': 'yearly',
+            'rebalancing_strength': 1.0,
+            'zone_drift_threshold': 0.1,
+            'zone_rebalancing_enabled': True,
+            'zone_allocation_precision': 0.8
         }
 
         for key, value in defaults.items():
@@ -572,7 +576,9 @@ class SimulationController:
                 portfolio.loans if hasattr(portfolio, 'loans') else [],
                 fund,
                 market_conditions,
-                self.config
+                self.config,
+                float(self.config.get('rebalancing_strength', 1.0)),
+                bool(self.config.get('zone_rebalancing_enabled', True))
             )
             granularity = self.config.get('time_granularity', 'yearly')
             if granularity == 'monthly':

--- a/src/backend/models_pkg/fund.py
+++ b/src/backend/models_pkg/fund.py
@@ -95,6 +95,9 @@ class Fund:
         self.interest_rate = self._parse_decimal(config.get('interest_rate', '0.05'), 'interest_rate')
         self.origination_fee_rate = self._parse_decimal(config.get('origination_fee_rate', '0.02'), 'origination_fee_rate')
         self.zone_allocation_precision = self._parse_decimal(config.get('zone_allocation_precision', '0.8'), 'zone_allocation_precision')
+        self.rebalancing_strength = self._parse_decimal(config.get('rebalancing_strength', '0.5'), 'rebalancing_strength')
+        self.zone_drift_threshold = self._parse_decimal(config.get('zone_drift_threshold', '0.1'), 'zone_drift_threshold')
+        self.zone_rebalancing_enabled = bool(config.get('zone_rebalancing_enabled', True))
 
         # Exit parameters
         self.average_exit_year = self._parse_decimal(config.get('average_exit_year', str(self.term - 2)), 'average_exit_year')
@@ -285,6 +288,9 @@ class Fund:
             'interest_rate': str(self.interest_rate),
             'origination_fee_rate': str(self.origination_fee_rate),
             'zone_allocation_precision': str(self.zone_allocation_precision),
+            'rebalancing_strength': str(self.rebalancing_strength),
+            'zone_drift_threshold': str(self.zone_drift_threshold),
+            'zone_rebalancing_enabled': self.zone_rebalancing_enabled,
             'average_exit_year': str(self.average_exit_year),
             'exit_year_std_dev': str(self.exit_year_std_dev),
             'exit_year_max_std_dev': str(self.exit_year_max_std_dev) if self.exit_year_max_std_dev is not None else None,


### PR DESCRIPTION
## Summary
- parse zone rebalancing parameters in `Fund`
- expose rebalancing defaults in simulation controller
- forward parameters to portfolio evolution
- maintain zone balance when enabled

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*