### PR TITLE
Add inner Monte Carlo support

### DIFF
--- a/src/backend/calculations/monte_carlo.py
+++ b/src/backend/calculations/monte_carlo.py
@@ -34,6 +34,8 @@ from calculations.optimization import optimize_portfolio, calculate_expected_ret
 from calculations.monte_carlo_pkg.parameter_selection import ParameterSelection
 from calculations.risk_decomposition import decompose_factors  # type: ignore
 
+from .portfolio_gen import generate_portfolio_from_config
+
 # We define run_single_simulation directly in this file
 # No need to import it from elsewhere
 
@@ -767,3 +769,22 @@ def prepare_monte_carlo_visualization_data(monte_carlo_results: Dict[str, Any]) 
         'efficient_frontier': efficient_frontier_chart,
         'summary_stats': summary_stats
     }
+
+
+def run_config_mc(
+    config: Dict[str, Any],
+    num_simulations: int = 1000,
+    progress_callback: Optional[Callable[[int, int], None]] = None,
+) -> Dict[str, Any]:
+    """Run Monte Carlo directly from a configuration dictionary."""
+    portfolio = generate_portfolio_from_config(config)
+    mc_results = run_monte_carlo_simulation(
+        fund_params=portfolio,
+        num_simulations=num_simulations,
+        variation_factor=config.get('variation_factor', 0.1),
+        seed=config.get('monte_carlo_seed'),
+        monte_carlo_parameters=config.get('monte_carlo_parameters'),
+        time_granularity=config.get('time_granularity', 'yearly'),
+        progress_callback=progress_callback,
+    )
+    return prepare_monte_carlo_visualization_data(mc_results)

--- a/src/backend/calculations/simulation_controller.py
+++ b/src/backend/calculations/simulation_controller.py
@@ -37,7 +37,7 @@ from .waterfall import calculate_waterfall_distribution
 from .performance import calculate_performance_metrics
 # Import monte_carlo functions
 try:
-    from .monte_carlo import generate_market_conditions, run_monte_carlo_simulation
+    from .monte_carlo import generate_market_conditions, run_monte_carlo_simulation, run_config_mc
 except ImportError as e:
     import logging
     logger = logging.getLogger(__name__)
@@ -81,6 +81,8 @@ except ImportError as e:
 
     def run_monte_carlo_simulation(*args, **kwargs):
         return {'monte_carlo_results': 'mocked'}
+    def run_config_mc(*args, **kwargs):
+        return {'summary_stats': {}}
 from .gp_entity import GPEntity
 from .multi_fund import MultiFundManager
 
@@ -126,6 +128,8 @@ class SimulationConfig(TypedDict, total=False):
     carried_interest_rate: float
     waterfall_structure: str
     monte_carlo_enabled: bool
+    inner_monte_carlo_enabled: bool
+    num_inner_simulations: int
     optimization_enabled: bool
     stress_testing_enabled: bool
     external_data_enabled: bool
@@ -147,6 +151,7 @@ class SimulationResults(TypedDict, total=False):
     performance_metrics: dict
     gp_entity_economics: dict
     monte_carlo_results: dict
+    inner_monte_carlo: dict
     optimization_results: dict
     stress_test_results: dict
     reports: dict
@@ -258,6 +263,8 @@ class SimulationController:
             'carried_interest_rate': 0.20,
             'waterfall_structure': 'european',
             'monte_carlo_enabled': False,
+            'inner_monte_carlo_enabled': False,
+            'num_inner_simulations': 1000,
             'optimization_enabled': False,
             'stress_testing_enabled': False,
             'external_data_enabled': False,
@@ -323,6 +330,19 @@ class SimulationController:
             # Step 2: Generate portfolio
             self._update_progress('portfolio', 0.2, "Generating portfolio")
             self._generate_portfolio()
+
+            if self.config.get('inner_monte_carlo_enabled', False):
+                self._update_progress('inner_monte_carlo', 0.25, 'Running inner Monte Carlo')
+                try:
+                    inner_results = run_config_mc(
+                        self.config,
+                        num_simulations=self.config.get('num_inner_simulations', 1000),
+                    )
+                    self.results['inner_monte_carlo'] = inner_results
+                except Exception as e:
+                    logger.error(f"Error running inner Monte Carlo: {str(e)}", exc_info=True)
+                    self.results['inner_monte_carlo'] = {}
+                    self.results['errors'] = self.results.get('errors', []) + [f"Inner Monte Carlo error: {str(e)}"]
 
             # Ensure time granularity is consistently applied across all calculations
             granularity = self._handle_granularity()


### PR DESCRIPTION
## Summary
- add a convenience `run_config_mc` helper in `monte_carlo.py`
- extend `SimulationController` configuration with `inner_monte_carlo_enabled` and `num_inner_simulations`
- when enabled, run inner Monte Carlo after portfolio generation and record stats

## Testing
- `python -m py_compile src/backend/calculations/monte_carlo.py src/backend/calculations/simulation_controller.py`
- `python -m pytest -q` *(fails: No module named pytest)*