### PR TITLE
Add inner Monte Carlo config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1350,3 +1350,4 @@ All notable changes to the Equihome Fund Simulation Engine will be documented in
 
 ### Added
 - **disable_carry_when_no_commitment** flag (default `true`) respected in both European and American waterfalls. When GP commitment is zero and the flag is true, carried‑interest rate is forced to 0 to reflect a manager‑only GP structure unless explicitly overridden.
+- Added `inner_monte_carlo_enabled` and `num_inner_simulations` parameters to simulation configuration schema for nested Monte Carlo support.

--- a/docs/Auditapr24/simulation_config_schema.md
+++ b/docs/Auditapr24/simulation_config_schema.md
@@ -80,7 +80,9 @@ This document defines the authoritative schema for all simulation configuration 
 
 ## **7. Advanced/Analytics**
 - `monte_carlo_enabled` (*optional*, `bool`): Enable Monte Carlo simulation. Default: `false`
+- `inner_monte_carlo_enabled` (*optional*, `bool`): Enable nested Monte Carlo simulation. Default: `false`
 - `num_simulations` (*optional*, `int`): Number of Monte Carlo runs. Default: `1000`
+- `num_inner_simulations` (*optional*, `int`): Number of inner simulations per outer run. Default: `1000`
 - `variation_factor` (*optional*, `float`): Parameter variation for MC. Default: `0.1`
 - `monte_carlo_seed` (*optional*, `int`): Random seed for MC. Default: `null`
 - `optimization_enabled` (*optional*, `bool`): Enable portfolio optimization. Default: `false`

--- a/docs/frontend/PARAMETER_TRACKING.md
+++ b/docs/frontend/PARAMETER_TRACKING.md
@@ -340,6 +340,8 @@ This change ensures that the backend respects the `deployment_monthly_granularit
 |-----------|------|-------------|---------|-------------|
 | `monte_carlo_enabled` | Boolean | Whether to enable Monte Carlo simulation | `false` | Checkbox |
 | `num_simulations` | Number | Number of Monte Carlo simulations to run | `1000` | Number input |
+| `inner_monte_carlo_enabled` | Boolean | Enable nested Monte Carlo simulation | `false` | Checkbox |
+| `num_inner_simulations` | Number | Number of inner simulations per outer run | `1000` | Number input |
 | `num_processes` | Number | Number of processes to use for parallel execution | `4` | Number input |
 | `random_seed` | Number | Random seed for reproducibility | `null` | Number input |
 | `distribution_type` | String | Type of probability distribution to use | `'normal'` | Dropdown |

--- a/src/backend/schemas/simulation_config_schema.json
+++ b/src/backend/schemas/simulation_config_schema.json
@@ -353,6 +353,18 @@
       "description": "Whether to run Monte Carlo simulation",
       "default": false
     },
+    "inner_monte_carlo_enabled": {
+      "type": "boolean",
+      "description": "Enable nested Monte Carlo simulation",
+      "default": false
+    },
+    "num_inner_simulations": {
+      "type": "integer",
+      "description": "Number of inner Monte Carlo simulations per outer run",
+      "minimum": 1,
+      "maximum": 10000,
+      "default": 1000
+    },
     "monte_carlo_parameters": {
       "type": "object",
       "description": "Advanced configuration for variable-level Monte Carlo sampling. Keys map to module names (e.g. exit_timing) and each contains a 'parameters' map of variable specs with base/dist/args.",


### PR DESCRIPTION
## Summary
- add `inner_monte_carlo_enabled` and `num_inner_simulations` to simulation config schema
- document new fields in schema docs
- document parameters in PARAMETER_TRACKING
- note new parameters in changelog

## Testing
- `pytest -q` *(fails: command not found)*