### PR TITLE
Update OpenAPI spec and SDK

### DIFF
--- a/src/backend/openapi.yaml
+++ b/src/backend/openapi.yaml
@@ -10,7 +10,7 @@ info:
     - Retrieving simulation results
     - Analyzing GP Entity economics
     - Real-time updates via WebSockets
-  version: 2.0.0
+  version: 2.1.0
   contact:
     name: Equihome Partners
 servers:
@@ -1181,6 +1181,10 @@ components:
         progress:
           type: number
           description: Progress of the simulation (0-1)
+        generated_at:
+          type: string
+          format: date-time
+          description: Timestamp when results were generated
         metrics:
           $ref: '#/components/schemas/PerformanceMetrics'
         performance_metrics:

--- a/src/frontend/src/api/SimulationApi.ts
+++ b/src/frontend/src/api/SimulationApi.ts
@@ -13,7 +13,7 @@ export class SimulationApi {
     constructor(config?: Partial<OpenAPIConfig>, HttpRequest: HttpRequestConstructor = AxiosHttpRequest) {
         this.request = new HttpRequest({
             BASE: config?.BASE ?? '',
-            VERSION: config?.VERSION ?? '2.0.0',
+            VERSION: config?.VERSION ?? '2.1.0',
             WITH_CREDENTIALS: config?.WITH_CREDENTIALS ?? false,
             CREDENTIALS: config?.CREDENTIALS ?? 'include',
             TOKEN: config?.TOKEN,

--- a/src/frontend/src/api/core/OpenAPI.ts
+++ b/src/frontend/src/api/core/OpenAPI.ts
@@ -21,7 +21,7 @@ export type OpenAPIConfig = {
 
 export const OpenAPI: OpenAPIConfig = {
     BASE: '',
-    VERSION: '2.0.0',
+    VERSION: '2.1.0',
     WITH_CREDENTIALS: false,
     CREDENTIALS: 'include',
     TOKEN: undefined,

--- a/src/frontend/src/api/models/SimulationResults.ts
+++ b/src/frontend/src/api/models/SimulationResults.ts
@@ -32,6 +32,10 @@ export type SimulationResults = {
      * Progress of the simulation (0-1)
      */
     progress?: number;
+    /**
+     * Timestamp when results were generated
+     */
+    generated_at?: string;
     metrics?: PerformanceMetrics;
     performance_metrics?: PerformanceMetrics;
     /**


### PR DESCRIPTION
## Summary
- bump OpenAPI version
- add `generated_at` timestamp to `SimulationResults`
- sync generated SDK files

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*