### PR TITLE
Add variance analysis config options

### DIFF
--- a/src/frontend/src/api/index.ts
+++ b/src/frontend/src/api/index.ts
@@ -16,3 +16,4 @@ export * from './models/BootstrapResults';
 export * from './models/GridStressResults';
 export * from './models/VintageVarResults';
 export * from './services/DefaultService';
+export * from './simulations';

--- a/src/frontend/src/api/simulations.ts
+++ b/src/frontend/src/api/simulations.ts
@@ -1,0 +1,19 @@
+import api from '../services/api';
+import { API_BASE_URL } from '../config';
+export interface VarianceAnalysisResult {
+  status?: string;
+  factors?: string[];
+  variance_matrix?: number[][];
+  explained_variance?: number[];
+}
+
+export const getVarianceAnalysis = async (
+  simulationId: string
+): Promise<VarianceAnalysisResult> => {
+  const endpoint = API_BASE_URL.endsWith('/')
+    ? `api/simulations/${simulationId}/variance-analysis`
+    : `/api/simulations/${simulationId}/variance-analysis`;
+  const response = await api.get(endpoint);
+  return response.data as VarianceAnalysisResult;
+};
+

--- a/src/frontend/src/components/wizard/steps/advanced-step.tsx
+++ b/src/frontend/src/components/wizard/steps/advanced-step.tsx
@@ -60,6 +60,23 @@ export function AdvancedStep() {
             step={1}
             placeholder="Random seed (optional)"
           />
+          <ParameterField
+            name="inner_monte_carlo_enabled"
+            label="Enable Inner Monte Carlo"
+            tooltip="Enable nested Monte Carlo simulations for variance analysis"
+            type="switch"
+            defaultValue={false}
+          />
+          <ParameterField
+            name="num_inner_simulations"
+            label="Inner Simulation Runs"
+            tooltip="Number of inner Monte Carlo simulations per outer iteration"
+            type="number"
+            min={1}
+            max={1000}
+            step={1}
+            defaultValue={100}
+          />
         </div>
       </FormSection>
 

--- a/src/frontend/src/schema/parameterSchema.ts
+++ b/src/frontend/src/schema/parameterSchema.ts
@@ -240,6 +240,26 @@ export const parameterSchema: ParameterSchemaEntry[] = [
     section: 'Monte Carlo Parameters',
     validation: {},
   },
+  {
+    key: 'inner_monte_carlo_enabled',
+    label: 'Enable Inner Monte Carlo',
+    type: 'boolean',
+    uiComponent: 'Checkbox',
+    defaultValue: false,
+    step: 'AnalysisSettings',
+    section: 'Monte Carlo Parameters',
+    validation: {},
+  },
+  {
+    key: 'num_inner_simulations',
+    label: 'Inner Simulation Runs',
+    type: 'number',
+    uiComponent: 'NumberInput',
+    defaultValue: 100,
+    step: 'AnalysisSettings',
+    section: 'Monte Carlo Parameters',
+    validation: { min: 1, max: 1000 },
+  },
   // Default Correlation parameters
   {
     key: 'default_correlation.enabled',

--- a/src/frontend/src/schemas/simulation-schema.ts
+++ b/src/frontend/src/schemas/simulation-schema.ts
@@ -71,6 +71,8 @@ export const simulationSchema = z.object({
   // 7. Advanced/Analytics
   monte_carlo_enabled: z.boolean().default(false),
   num_simulations: z.number().int().min(10).max(10000, "Number of simulations must be between 10 and 10,000").default(1000),
+  inner_monte_carlo_enabled: z.boolean().default(false),
+  num_inner_simulations: z.number().int().min(1).max(1000, "Number of inner simulations must be between 1 and 1,000").default(100),
   variation_factor: z.number().min(0).max(1, "Variation factor must be between 0 and 1").default(0.1),
   monte_carlo_seed: z.number().int().nullable().default(null),
   optimization_enabled: z.boolean().default(false),
@@ -146,6 +148,8 @@ export const defaultSimulationConfig: SimulationConfig = {
   // 7. Advanced/Analytics
   monte_carlo_enabled: false,
   num_simulations: 1000,
+  inner_monte_carlo_enabled: false,
+  num_inner_simulations: 100,
   variation_factor: 0.1,
   monte_carlo_seed: null,
   optimization_enabled: false,
@@ -222,7 +226,11 @@ export const wizardSteps = [
     title: 'Advanced',
     description: 'Configure advanced analytics and reporting',
     fields: [
-      'monte_carlo_enabled', 'num_simulations', 'variation_factor',
+      'monte_carlo_enabled',
+      'num_simulations',
+      'inner_monte_carlo_enabled',
+      'num_inner_simulations',
+      'variation_factor',
       'monte_carlo_seed', 'optimization_enabled', 'stress_testing_enabled',
       'external_data_enabled', 'generate_reports', 'gp_entity_enabled',
       'aggregate_gp_economics', 'report_config', 'stress_config', 'gp_entity',


### PR DESCRIPTION
## Summary
- add inner monte carlo parameters to parameter schema
- extend simulation-schema with inner monte carlo fields and wizard config
- render new fields in Advanced step of wizard
- expose `/variance-analysis` API call

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build` *(fails: TypeScript errors)*