### PR TITLE
Add variance analysis adapter

### DIFF
--- a/src/frontend/src/transformers/adapters/index.ts
+++ b/src/frontend/src/transformers/adapters/index.ts
@@ -10,4 +10,5 @@ export * from './gpEntityAdapter';
 export * from './bootstrapAdapter';
 export * from './gridStressAdapter';
 export * from './vintageVarAdapter';
-export * from './zoneMetricsAdapter'; 
+export * from './zoneMetricsAdapter';
+export * from './varianceAdapter';

--- a/src/frontend/src/transformers/adapters/varianceAdapter.ts
+++ b/src/frontend/src/transformers/adapters/varianceAdapter.ts
@@ -1,0 +1,66 @@
+export interface VarianceFanChartSeries {
+  label: string;
+  data: number[];
+  color?: string;
+}
+
+export interface VarianceFanChart {
+  labels: number[];
+  series: VarianceFanChartSeries[];
+}
+
+export interface DispersionOverlayData {
+  labels: string[];
+  values: number[];
+}
+
+export interface VarianceAnalysisModel {
+  fanChart: VarianceFanChart | null;
+  dispersion: DispersionOverlayData | null;
+}
+
+import { safeExtract } from '../core/utils';
+import { wrapTransformError, logTransformWarning } from '../core/errorHandling';
+
+export namespace VarianceAdapter {
+  export const transform = wrapTransformError((apiResponse: any): VarianceAnalysisModel => {
+    if (!apiResponse) {
+      logTransformWarning('Empty API response for variance analysis', apiResponse);
+      return { fanChart: null, dispersion: null };
+    }
+
+    const fanChart = transformFanChart(apiResponse.fan_chart || apiResponse.fanChart);
+    const dispersion = transformDispersion(apiResponse.dispersion);
+
+    return { fanChart, dispersion };
+  }, 'Variance analysis transformation error');
+
+  function transformFanChart(data: any): VarianceFanChart | null {
+    if (!data) return null;
+    const labels = safeExtract(data, ['labels'], []);
+    const series: VarianceFanChartSeries[] = [];
+
+    const p5 = safeExtract(data, ['p5'], null);
+    const p10 = safeExtract(data, ['p10'], null);
+    const p50 = safeExtract(data, ['p50'], null);
+    const p90 = safeExtract(data, ['p90'], null);
+    const p95 = safeExtract(data, ['p95'], null);
+    const mean = safeExtract(data, ['mean'], null);
+
+    if (Array.isArray(p5)) series.push({ label: 'P5', data: p5 });
+    if (Array.isArray(p10)) series.push({ label: 'P10', data: p10 });
+    if (Array.isArray(p50)) series.push({ label: 'P50', data: p50 });
+    if (Array.isArray(p90)) series.push({ label: 'P90', data: p90 });
+    if (Array.isArray(p95)) series.push({ label: 'P95', data: p95 });
+    if (Array.isArray(mean)) series.push({ label: 'Mean', data: mean });
+
+    return { labels, series };
+  }
+
+  function transformDispersion(data: any): DispersionOverlayData | null {
+    if (!data) return null;
+    const labels = safeExtract(data, ['labels'], []);
+    const values = safeExtract(data, ['values'], []);
+    return { labels, values };
+  }
+}

--- a/src/frontend/tests/transformers/VarianceAdapter.test.ts
+++ b/src/frontend/tests/transformers/VarianceAdapter.test.ts
@@ -1,0 +1,36 @@
+import { VarianceAdapter } from '../../src/transformers/adapters';
+
+describe('VarianceAdapter', () => {
+  describe('transform', () => {
+    it('should transform variance analysis data correctly', () => {
+      const apiResponse = {
+        fan_chart: {
+          labels: [1, 2, 3],
+          p5: [0.1, 0.2, 0.3],
+          p50: [0.15, 0.25, 0.35],
+          p95: [0.2, 0.3, 0.4],
+          mean: [0.16, 0.26, 0.36]
+        },
+        dispersion: {
+          labels: ['A', 'B', 'C'],
+          values: [5, 10, 15]
+        }
+      };
+
+      const result = VarianceAdapter.transform(apiResponse);
+
+      expect(result.fanChart?.labels).toEqual([1, 2, 3]);
+      expect(result.fanChart?.series).toHaveLength(4);
+      expect(result.fanChart?.series[0].label).toBe('P5');
+      expect(result.fanChart?.series[0].data).toEqual([0.1, 0.2, 0.3]);
+      expect(result.dispersion?.labels).toEqual(['A', 'B', 'C']);
+      expect(result.dispersion?.values).toEqual([5, 10, 15]);
+    });
+
+    it('should handle empty input gracefully', () => {
+      const result = VarianceAdapter.transform(null as any);
+      expect(result.fanChart).toBeNull();
+      expect(result.dispersion).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- implement `VarianceAdapter` for fan-chart and dispersion data
- export adapter in transformation index
- add unit tests for the new adapter

## Testing
- `npm test` *(fails: Cannot find module 'node-fetch')*