### PR TITLE
Add variance analysis endpoint

### DIFF
--- a/src/backend/calculations/variance_analysis.py
+++ b/src/backend/calculations/variance_analysis.py
@@ -1,0 +1,68 @@
+"""Variance analysis utilities for running multiple seeded simulations."""
+from __future__ import annotations
+
+from typing import Dict, Any, List, Tuple
+import numpy as np
+import logging
+
+from .simulation_controller import SimulationController
+from .statistics import RiskMetrics
+
+logger = logging.getLogger(__name__)
+
+
+def run_config_mc(config: Dict[str, Any], num_inner_simulations: int = 10) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    """Run a simulation configuration multiple times with different seeds.
+
+    Args:
+        config: Simulation configuration dictionary.
+        num_inner_simulations: Number of seeded runs to execute.
+
+    Returns:
+        Tuple of (aggregated metrics, per-seed results).
+    """
+    irr_values: List[float] = []
+    seed_results: List[Dict[str, Any]] = []
+
+    base_seed = int(config.get("monte_carlo_seed", 0) or 0)
+    for i in range(num_inner_simulations):
+        run_seed = base_seed + i
+        cfg = dict(config)
+        cfg["monte_carlo_seed"] = run_seed
+        try:
+            controller = SimulationController(cfg)
+            # disable progress callbacks for internal runs
+            controller.set_progress_callback(lambda *a, **k: None)
+            res = controller.run_simulation()
+            irr = res.get("performance_metrics", {}).get("irr")
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Variance analysis run failed: %s", exc, exc_info=True)
+            irr = None
+            res = {}
+        if irr is not None:
+            irr_values.append(irr)
+        seed_results.append({"seed": run_seed, "irr": irr})
+
+    irr_array = np.array(irr_values) if irr_values else np.array([])
+
+    if irr_array.size > 0:
+        irr_percentiles = {
+            "p5": float(np.percentile(irr_array, 5)),
+            "p50": float(np.percentile(irr_array, 50)),
+            "p95": float(np.percentile(irr_array, 95)),
+        }
+        var_percentiles = {
+            "p95": float(RiskMetrics.value_at_risk(irr_array, confidence_level=0.95)),
+            "p99": float(RiskMetrics.value_at_risk(irr_array, confidence_level=0.99)),
+        }
+    else:  # pragma: no cover - empty result case
+        irr_percentiles = {"p5": None, "p50": None, "p95": None}
+        var_percentiles = {"p95": None, "p99": None}
+
+    aggregated = {
+        "iterations": num_inner_simulations,
+        "irr_percentiles": irr_percentiles,
+        "var_percentiles": var_percentiles,
+    }
+
+    return aggregated, seed_results

--- a/src/backend/openapi.yaml
+++ b/src/backend/openapi.yaml
@@ -348,6 +348,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/simulations/{simulation_id}/variance-analysis:
+    post:
+      summary: Run Variance Analysis
+      description: Run Monte Carlo variance analysis for an existing simulation configuration.
+      parameters:
+        - name: simulation_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: num_inner_simulations
+          in: query
+          description: Number of Monte Carlo repetitions to run
+          schema:
+            type: integer
+            default: 10
+        - name: include_seed_results
+          in: query
+          description: Include individual seed results in the response
+          schema:
+            type: boolean
+            default: false
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VarianceAnalysisResults'
+        '404':
+          description: Not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/simulations/{simulation_id}/loans/:
     get:
       summary: Get Simulation Loans
@@ -1318,6 +1355,32 @@ components:
               value_at_risk:
                 type: number
                 description: IRR at the specified downside percentile
+    VarianceAnalysisResults:
+      title: VarianceAnalysisResults
+      description: Aggregated IRR and VaR statistics from multi-seed variance analysis.
+      type: object
+      properties:
+        iterations:
+          type: integer
+          description: Number of inner simulations executed
+        irr_percentiles:
+          type: object
+          properties:
+            p5: { type: number }
+            p50: { type: number }
+            p95: { type: number }
+        var_percentiles:
+          type: object
+          properties:
+            p95: { type: number }
+            p99: { type: number }
+        seed_results:
+          type: array
+          items:
+            type: object
+            properties:
+              seed: { type: integer }
+              irr: { type: number }
     ZoneMetrics:
       title: ZoneMetrics
       description: Traffic-Light metrics for a single suburb / zone.

--- a/tests/test_variance_analysis.py
+++ b/tests/test_variance_analysis.py
@@ -1,0 +1,37 @@
+import time
+from fastapi.testclient import TestClient
+from src.backend.api.main import app
+from tests.test_headless_backend_full import FULL_CONFIG
+
+client = TestClient(app)
+
+
+def wait_for_completion(sim_id: str, timeout: float = 30):
+    deadline = time.time() + timeout
+    while True:
+        status_resp = client.get(f"/api/simulations/{sim_id}/status")
+        assert status_resp.status_code == 200, status_resp.text
+        status = status_resp.json()
+        if status["status"] == "completed":
+            return
+        if status["status"] == "failed":
+            raise AssertionError(f"Simulation failed: {status}")
+        if time.time() > deadline:
+            raise TimeoutError("Simulation did not complete in time")
+        time.sleep(0.5)
+
+
+def test_variance_analysis_endpoint():
+    resp = client.post("/api/simulations", json=FULL_CONFIG)
+    assert resp.status_code == 200, resp.text
+    sim_id = resp.json()["simulation_id"]
+    wait_for_completion(sim_id)
+
+    var_resp = client.post(
+        f"/api/simulations/{sim_id}/variance-analysis",
+        params={"num_inner_simulations": 2},
+    )
+    assert var_resp.status_code == 200, var_resp.text
+    data = var_resp.json()
+    assert "irr_percentiles" in data
+    assert "var_percentiles" in data


### PR DESCRIPTION
## Summary
- implement Monte Carlo variance analysis util
- expose `/api/simulations/{simulation_id}/variance-analysis` endpoint
- document new endpoint in `openapi.yaml`
- provide tests for variance analysis

## Testing
- `python -m pytest -k variance_analysis -q` *(fails: No module named pytest)*