### PR TITLE
Add detailed Monte Carlo schema

### DIFF
--- a/src/backend/openapi.yaml
+++ b/src/backend/openapi.yaml
@@ -126,7 +126,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                $ref: '#/components/schemas/MonteCarloVisualization'
                 properties:
                   message:
                     type: string
@@ -1237,8 +1237,7 @@ components:
           type: object
           description: Waterfall distribution results
         monte_carlo_results:
-          type: object
-          description: Monte Carlo simulation results
+          $ref: '#/components/schemas/MonteCarloResults'
         bootstrap_results:
           $ref: '#/components/schemas/BootstrapResults'
         grid_stress_results:
@@ -1435,3 +1434,216 @@ components:
           type: number
         total_interest:
           type: number
+
+    MonteCarloHistogramBin:
+      title: MonteCarloHistogramBin
+      type: object
+      properties:
+        bin:
+          type: number
+        frequency:
+          type: number
+
+    MonteCarloDistributionSummary:
+      title: MonteCarloDistributionSummary
+      type: object
+      properties:
+        min:
+          type: number
+        max:
+          type: number
+        mean:
+          type: number
+        median:
+          type: number
+        stdDev:
+          type: number
+        percentiles:
+          type: object
+          properties:
+            p10:
+              type: number
+            p25:
+              type: number
+            p50:
+              type: number
+            p75:
+              type: number
+            p90:
+              type: number
+        histogram:
+          type: array
+          items:
+            $ref: '#/components/schemas/MonteCarloHistogramBin'
+
+    MonteCarloResults:
+      title: MonteCarloResults
+      description: Results from Monte Carlo simulations.
+      type: object
+      properties:
+        distributions:
+          type: object
+          properties:
+            irr:
+              $ref: '#/components/schemas/MonteCarloDistributionSummary'
+            multiple:
+              $ref: '#/components/schemas/MonteCarloDistributionSummary'
+            default_rate:
+              $ref: '#/components/schemas/MonteCarloDistributionSummary'
+        sensitivity:
+          type: array
+          items:
+            type: object
+            properties:
+              parameter:
+                type: string
+              impact:
+                type: number
+              correlation:
+                type: number
+        efficient_frontier:
+          type: array
+          items:
+            type: object
+        convergence:
+          type: object
+          properties:
+            running_mean:
+              type: array
+              items:
+                type: number
+            running_ci:
+              type: array
+              items:
+                type: number
+        factor_decomposition:
+          type: object
+        num_simulations:
+          type: integer
+        variation_factor:
+          type: number
+        time_granularity:
+          type: string
+        simulation_results:
+          type: array
+          items:
+            type: object
+        errors:
+          type: array
+          items:
+            type: object
+
+    MonteCarloChartDataset:
+      title: MonteCarloChartDataset
+      type: object
+      properties:
+        label:
+          type: string
+        data:
+          type: array
+          items:
+            type: number
+        color:
+          type: string
+          nullable: true
+
+    MonteCarloStatistics:
+      title: MonteCarloStatistics
+      type: object
+      properties:
+        min:
+          type: number
+          nullable: true
+        max:
+          type: number
+          nullable: true
+        mean:
+          type: number
+          nullable: true
+        median:
+          type: number
+          nullable: true
+        std_dev:
+          type: number
+          nullable: true
+        percentiles:
+          type: object
+          properties:
+            p10:
+              type: number
+              nullable: true
+            p25:
+              type: number
+              nullable: true
+            p50:
+              type: number
+              nullable: true
+            p75:
+              type: number
+              nullable: true
+            p90:
+              type: number
+              nullable: true
+
+    MonteCarloDistributionModel:
+      title: MonteCarloDistributionModel
+      type: object
+      properties:
+        labels:
+          type: array
+          items:
+            type: number
+        datasets:
+          type: array
+          items:
+            $ref: '#/components/schemas/MonteCarloChartDataset'
+        statistics:
+          $ref: '#/components/schemas/MonteCarloStatistics'
+
+    MonteCarloSensitivityModel:
+      title: MonteCarloSensitivityModel
+      type: object
+      properties:
+        labels:
+          type: array
+          items:
+            type: string
+        datasets:
+          type: array
+          items:
+            $ref: '#/components/schemas/MonteCarloChartDataset'
+
+    MonteCarloConfidenceModel:
+      title: MonteCarloConfidenceModel
+      type: object
+      properties:
+        mean:
+          type: number
+          nullable: true
+        median:
+          type: number
+          nullable: true
+        confidence_intervals:
+          type: object
+          properties:
+            p10_p90:
+              type: array
+              minItems: 2
+              maxItems: 2
+              items:
+                type: number
+                nullable: true
+            p25_p75:
+              type: array
+              minItems: 2
+              maxItems: 2
+              items:
+                type: number
+                nullable: true
+
+    MonteCarloVisualization:
+      title: MonteCarloVisualization
+      oneOf:
+        - $ref: '#/components/schemas/MonteCarloDistributionModel'
+        - $ref: '#/components/schemas/MonteCarloSensitivityModel'
+        - $ref: '#/components/schemas/MonteCarloConfidenceModel'

--- a/src/frontend/src/api/index.ts
+++ b/src/frontend/src/api/index.ts
@@ -15,4 +15,6 @@ export * from './models/SimulationResults';
 export * from './models/BootstrapResults';
 export * from './models/GridStressResults';
 export * from './models/VintageVarResults';
+export * from './models/MonteCarloResults';
+export * from './models/MonteCarloVisualization';
 export * from './services/DefaultService';

--- a/src/frontend/src/api/models/MonteCarloResults.ts
+++ b/src/frontend/src/api/models/MonteCarloResults.ts
@@ -1,0 +1,49 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * Results from Monte Carlo simulations.
+ */
+export type MonteCarloResults = {
+    distributions?: {
+        irr?: MonteCarloDistributionSummary;
+        multiple?: MonteCarloDistributionSummary;
+        default_rate?: MonteCarloDistributionSummary;
+    };
+    sensitivity?: Array<{
+        parameter?: string;
+        impact?: number;
+        correlation?: number;
+    }>;
+    efficient_frontier?: Array<Record<string, any>>;
+    convergence?: {
+        running_mean?: Array<number>;
+        running_ci?: Array<number>;
+    };
+    factor_decomposition?: Record<string, any>;
+    num_simulations?: number;
+    variation_factor?: number;
+    time_granularity?: string;
+    simulation_results?: Array<Record<string, any>>;
+    errors?: Array<Record<string, any>>;
+};
+
+export type MonteCarloDistributionSummary = {
+    min?: number;
+    max?: number;
+    mean?: number;
+    median?: number;
+    stdDev?: number;
+    percentiles?: {
+        p10?: number;
+        p25?: number;
+        p50?: number;
+        p75?: number;
+        p90?: number;
+    };
+    histogram?: Array<{
+        bin?: number;
+        frequency?: number;
+    }>;
+};

--- a/src/frontend/src/api/models/MonteCarloVisualization.ts
+++ b/src/frontend/src/api/models/MonteCarloVisualization.ts
@@ -1,0 +1,50 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type MonteCarloDistributionModel = {
+    labels?: Array<number>;
+    datasets?: Array<MonteCarloChartDataset>;
+    statistics?: MonteCarloStatistics;
+};
+
+export type MonteCarloSensitivityModel = {
+    labels?: Array<string>;
+    datasets?: Array<MonteCarloChartDataset>;
+};
+
+export type MonteCarloConfidenceModel = {
+    mean?: number | null;
+    median?: number | null;
+    confidence_intervals?: {
+        p10_p90?: [number | null, number | null];
+        p25_p75?: [number | null, number | null];
+    };
+};
+
+export type MonteCarloVisualization =
+    | { type: 'distribution'; data: MonteCarloDistributionModel }
+    | { type: 'sensitivity'; data: MonteCarloSensitivityModel }
+    | { type: 'confidence'; data: MonteCarloConfidenceModel };
+
+export type MonteCarloChartDataset = {
+    label?: string;
+    data?: Array<number>;
+    color?: string | null;
+};
+
+export type MonteCarloStatistics = {
+    min?: number | null;
+    max?: number | null;
+    mean?: number | null;
+    median?: number | null;
+    std_dev?: number | null;
+    percentiles?: {
+        p10?: number | null;
+        p25?: number | null;
+        p50?: number | null;
+        p75?: number | null;
+        p90?: number | null;
+    };
+};

--- a/src/frontend/src/api/models/SimulationResults.ts
+++ b/src/frontend/src/api/models/SimulationResults.ts
@@ -8,6 +8,7 @@ import type { PerformanceMetrics } from './PerformanceMetrics';
 import type { PortfolioEvolution } from './PortfolioEvolution';
 import type { SimulationConfig } from './SimulationConfig';
 import type { VintageVarResults } from './VintageVarResults';
+import type { MonteCarloResults } from './MonteCarloResults';
 /**
  * Results of a simulation.
  */
@@ -81,7 +82,7 @@ export type SimulationResults = {
     /**
      * Monte Carlo simulation results
      */
-    monte_carlo_results?: Record<string, any>;
+    monte_carlo_results?: MonteCarloResults;
     bootstrap_results?: BootstrapResults;
     grid_stress_results?: GridStressResults;
     vintage_var?: VintageVarResults;

--- a/src/frontend/src/api/services/DefaultService.ts
+++ b/src/frontend/src/api/services/DefaultService.ts
@@ -12,6 +12,7 @@ import type { SimulationList } from '../models/SimulationList';
 import type { SimulationResponse } from '../models/SimulationResponse';
 import type { SimulationResults } from '../models/SimulationResults';
 import type { SimulationStatus } from '../models/SimulationStatus';
+import type { MonteCarloVisualization } from '../models/MonteCarloVisualization';
 import type { ZoneMetrics } from '../models/ZoneMetrics';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import type { BaseHttpRequest } from '../core/BaseHttpRequest';
@@ -231,7 +232,7 @@ export class DefaultService {
         endYear?: number,
         format: string = 'bar',
         metrics?: string,
-    ): CancelablePromise<Record<string, any>> {
+    ): CancelablePromise<MonteCarloVisualization> {
         return this.httpRequest.request({
             method: 'GET',
             url: '/api/simulations/{simulation_id}/visualization',

--- a/src/frontend/src/transformers/adapters/monteCarloAdapter.ts
+++ b/src/frontend/src/transformers/adapters/monteCarloAdapter.ts
@@ -69,7 +69,7 @@ export namespace MonteCarloAdapter {
       max: normalize(statistics.max, null),
       mean: normalize(statistics.mean, null),
       median: normalize(statistics.median, null),
-      std_dev: normalize(statistics.std_dev, null),
+      std_dev: normalize(statistics.std_dev ?? statistics.stdDev, null),
       percentiles: {
         p10: normalize(statistics.percentiles?.p10, null),
         p25: normalize(statistics.percentiles?.p25, null),


### PR DESCRIPTION
## Summary
- type `monte_carlo_results` with new MonteCarloResults schema in `openapi.yaml`
- describe Monte Carlo visualization models in OpenAPI
- update generated TypeScript models to match new schemas
- adjust DefaultService to return typed MonteCarloVisualization
- normalize stdDev field in MonteCarloAdapter

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: missing test script)*
- `python -m pytest tests` *(fails: No module named pytest)*