### PR TITLE
Update docs for inner Monte Carlo and variance API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1350,3 +1350,4 @@ All notable changes to the Equihome Fund Simulation Engine will be documented in
 
 ### Added
 - **disable_carry_when_no_commitment** flag (default `true`) respected in both European and American waterfalls. When GP commitment is zero and the flag is true, carried‑interest rate is forced to 0 to reflect a manager‑only GP structure unless explicitly overridden.
+- Documented inner Monte Carlo parameters and new `/variance-analysis` usage examples.

--- a/docs/frontend/PARAMETER_TRACKING.md
+++ b/docs/frontend/PARAMETER_TRACKING.md
@@ -375,6 +375,16 @@ This change ensures that the backend respects the `deployment_monthly_granularit
 | `monte_carlo_parameters.market_conditions.cycle_length_years` | Number | Average length of market cycle in years | `5` | Number input |
 | `monte_carlo_parameters.market_conditions.cycle_amplitude` | Number | Amplitude of market cycles | `0.3` | Slider |
 
+### Inner Monte Carlo Parameters
+
+| Parameter | Type | Description | Default | UI Component |
+|-----------|------|-------------|---------|-------------|
+| `monte_carlo_parameters.inner.iterations` | Number | Number of inner simulations run for each outer iteration | `100` | Number input |
+| `monte_carlo_parameters.inner.processes` | Number | Parallel processes for inner loop execution | `2` | Number input |
+| `monte_carlo_parameters.inner.seed` | Number | Random seed for inner simulations | `null` | Number input |
+
+These options appear in the wizard under **Advanced Monte Carlo Options** once Monte Carlo is enabled. They allow fine‑tuning of nested simulations used for variance analysis.
+
 ### Sensitivity Analysis Parameters
 
 | Parameter | Type | Description | Default | UI Component |

--- a/docs/guides/API_CAPABILITIES.md
+++ b/docs/guides/API_CAPABILITIES.md
@@ -417,6 +417,22 @@ const stressTestResults = results?.stress_test_results;
 // const stressTestResults = await client.getStressTestResults(simulationId, {...});
 ```
 
+### Run Variance Analysis
+
+```javascript
+// Compare the variance of key metrics across multiple simulations
+// POST /variance-analysis
+const stats = await client.post('/variance-analysis', {
+  simulation_ids: ['sim1', 'sim2'],
+  metrics: ['irr', 'equity_multiple']
+});
+
+console.log('IRR variance:', stats.irr.variance);
+console.log('Equity multiple CV:', stats.equity_multiple.coefficient_of_variation);
+```
+
+The endpoint returns statistical measures (mean, variance, standard deviation and coefficient of variation) for each requested metric. These can be displayed in tables or charts to illustrate dispersion between simulation runs.
+
 ## UI Integration Examples
 
 The API is designed to support a wide range of UI components, including:


### PR DESCRIPTION
## Summary
- document inner Monte Carlo parameters in PARAMETER_TRACKING
- add variance-analysis example to API_CAPABILITIES
- note documentation changes in CHANGELOG

## Testing
- `pytest` *(fails: command not found)*
- `npm test` *(fails: missing script)*