### PR TITLE
Add grid stress and vintage VaR integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Equihome Fund Simulation Engine will be documented in this file. This serves as a progress tracker and memory aid for development.
 
+## [2025-05-17] Grid Stress & Vintage VaR
+
+### Added
+- Integrated grid stress analysis and vintage Value-at-Risk into `SimulationController`.
+- New config flags `grid_stress_enabled` and `vintage_var_enabled` with defaults.
+- Results stored under `grid_stress_results` and `vintage_var`.
+
 ## [2025-04-17] API Connectivity Fixes 
 
 ### Fixed


### PR DESCRIPTION
## Summary
- wire `grid_stress_analysis.run_grid` and `vintage_var_analysis.run_vintage_var` into `SimulationController`
- add defaults for `grid_stress_enabled`, `grid_stress_axes`, `grid_stress_steps`, and `vintage_var_enabled`
- record new feature in `CHANGELOG`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*