### PR TITLE
Update leverage docs

### DIFF
--- a/docs/frontend/LEVERAGE_UI_GUIDE.md
+++ b/docs/frontend/LEVERAGE_UI_GUIDE.md
@@ -56,6 +56,7 @@ const resp = await LeverageService.postApiLeveragePreview({
 ```
 
 3. Persist the whole `leverage` object into the simulation config payload.
+4. To compare levered vs unlevered results, enable the `run_dual_leverage_comparison` toggle ([see parameter](./PARAMETER_TRACKING.md)).
 
 ---
 

--- a/docs/frontend/PARAMETER_TRACKING.md
+++ b/docs/frontend/PARAMETER_TRACKING.md
@@ -35,6 +35,7 @@ The following parameters have been added to support enhanced features in the sim
 | `leverage.ramp_line.draw_period_months` | Integer | Draw window length in months | `24` | Number input |
 | `leverage.ramp_line.spread_bps` | Integer | Spread on ramp line (bps) | `300` | Number input |
 | `leverage.dynamic_rules` | Array | IF/THEN leverage rules (JSON) | `[]` | Advanced editor |
+| `run_dual_leverage_comparison` | Boolean | Run an unlevered control simulation alongside the levered scenario | `false` | Checkbox |
 
 ### Default Correlation Parameters
 


### PR DESCRIPTION
## Summary
- document `run_dual_leverage_comparison` in Parameter Tracking
- mention the dual levered/unlevered comparison toggle in the Leverage UI guide

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*
- `npm test` in `src/frontend` *(fails: missing test script)*