### PR TITLE
Add leverage config to SimulationConfig

### DIFF
--- a/src/backend/calculations/simulation_controller.py
+++ b/src/backend/calculations/simulation_controller.py
@@ -265,6 +265,7 @@ class SimulationController:
             'gp_entity_enabled': False,
             'aggregate_gp_economics': True,
             'monte_carlo_parameters': {},
+            'leverage': {},
             'deployment_monthly_granularity': False,
             'time_granularity': 'yearly'
         }


### PR DESCRIPTION
## Summary
- define LeverageConfig pydantic model
- extend SimulationConfig with leverage field
- disallow unknown keys in SimulationConfig
- keep leverage dictionary in controller defaults

## Testing
- `pip install pytest` *(fails: Could not connect to proxy)*
- `python -m pytest -q` *(fails: No module named pytest)*