### PR TITLE
Add leverage config to simulation schemas

### DIFF
--- a/src/backend/openapi.yaml
+++ b/src/backend/openapi.yaml
@@ -843,6 +843,8 @@ components:
           description: Time granularity for simulation (yearly or monthly)
           enum: [yearly, monthly]
           default: yearly
+        leverage:
+          $ref: '#/components/schemas/LeverageConfig'
     SimulationResponse:
       title: SimulationResponse
       description: Response for a simulation creation request.
@@ -1245,6 +1247,8 @@ components:
           $ref: '#/components/schemas/GridStressResults'
         vintage_var:
           $ref: '#/components/schemas/VintageVarResults'
+        leverage:
+          $ref: '#/components/schemas/LeverageMetrics'
         fund_size:
           type: number
           description: Fund size

--- a/src/frontend/src/api/index.ts
+++ b/src/frontend/src/api/index.ts
@@ -15,4 +15,8 @@ export * from './models/SimulationResults';
 export * from './models/BootstrapResults';
 export * from './models/GridStressResults';
 export * from './models/VintageVarResults';
+export * from './models/LeverageConfig';
+export * from './models/LeverageMetrics';
+export * from './models/LeveragePreviewRequest';
+export * from './models/LeveragePreviewResponse';
 export * from './services/DefaultService';

--- a/src/frontend/src/api/models/SimulationConfig.ts
+++ b/src/frontend/src/api/models/SimulationConfig.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { LeverageConfig } from './LeverageConfig';
 /**
  * Configuration for a simulation.
  */
@@ -189,6 +190,7 @@ export type SimulationConfig = {
      * Time granularity for simulation (yearly or monthly)
      */
     time_granularity?: SimulationConfig.time_granularity;
+    leverage?: LeverageConfig;
 };
 export namespace SimulationConfig {
     /**

--- a/src/frontend/src/api/models/SimulationResults.ts
+++ b/src/frontend/src/api/models/SimulationResults.ts
@@ -8,6 +8,7 @@ import type { PerformanceMetrics } from './PerformanceMetrics';
 import type { PortfolioEvolution } from './PortfolioEvolution';
 import type { SimulationConfig } from './SimulationConfig';
 import type { VintageVarResults } from './VintageVarResults';
+import type { LeverageMetrics } from './LeverageMetrics';
 /**
  * Results of a simulation.
  */
@@ -85,6 +86,7 @@ export type SimulationResults = {
     bootstrap_results?: BootstrapResults;
     grid_stress_results?: GridStressResults;
     vintage_var?: VintageVarResults;
+    leverage?: LeverageMetrics;
     /**
      * Fund size
      */


### PR DESCRIPTION
## Summary
- add `leverage` block to `SimulationConfig` in OpenAPI spec
- include leverage metrics in `SimulationResults`
- expose leverage models in the frontend API index
- update generated TypeScript models for new schema fields

## Testing
- `./generate-sdk.sh` *(failed: connect EHOSTUNREACH)*