### PR TITLE
Add leverage fields to OpenAPI and SDK

### DIFF
--- a/src/backend/openapi.yaml
+++ b/src/backend/openapi.yaml
@@ -838,6 +838,8 @@ components:
             report_template: summary
             export_format: json
             include_charts: true
+        leverage:
+          $ref: '#/components/schemas/LeverageConfig'
         time_granularity:
           type: string
           description: Time granularity for simulation (yearly or monthly)
@@ -1245,6 +1247,8 @@ components:
           $ref: '#/components/schemas/GridStressResults'
         vintage_var:
           $ref: '#/components/schemas/VintageVarResults'
+        leverage_metrics:
+          $ref: '#/components/schemas/LeverageMetrics'
         fund_size:
           type: number
           description: Fund size

--- a/src/frontend/src/api/models/SimulationConfig.ts
+++ b/src/frontend/src/api/models/SimulationConfig.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { LeverageConfig } from './LeverageConfig';
 /**
  * Configuration for a simulation.
  */
@@ -185,6 +186,7 @@ export type SimulationConfig = {
      * Report configuration
      */
     report_config?: Record<string, any>;
+    leverage?: LeverageConfig;
     /**
      * Time granularity for simulation (yearly or monthly)
      */

--- a/src/frontend/src/api/models/SimulationResults.ts
+++ b/src/frontend/src/api/models/SimulationResults.ts
@@ -8,6 +8,7 @@ import type { PerformanceMetrics } from './PerformanceMetrics';
 import type { PortfolioEvolution } from './PortfolioEvolution';
 import type { SimulationConfig } from './SimulationConfig';
 import type { VintageVarResults } from './VintageVarResults';
+import type { LeverageMetrics } from './LeverageMetrics';
 /**
  * Results of a simulation.
  */
@@ -85,6 +86,7 @@ export type SimulationResults = {
     bootstrap_results?: BootstrapResults;
     grid_stress_results?: GridStressResults;
     vintage_var?: VintageVarResults;
+    leverage_metrics?: LeverageMetrics;
     /**
      * Fund size
      */


### PR DESCRIPTION
## Summary
- expose `LeverageConfig` in `SimulationConfig` schema
- expose `leverage_metrics` in `SimulationResults` schema
- regenerate SDK files manually to include leverage types

## Testing
- `pytest` *(fails: command not found)*
- `bash generate-sdk.sh` *(fails: EHOSTUNREACH when installing dependencies)*