### PR TITLE
Remove fallback logic for optional modules

### DIFF
--- a/src/backend/calculations/simulation_controller.py
+++ b/src/backend/calculations/simulation_controller.py
@@ -35,84 +35,46 @@ from .loan_lifecycle import model_portfolio_evolution_from_config, model_portfol
 from .cash_flows import project_cash_flows, project_cash_flows_granular
 from .waterfall import calculate_waterfall_distribution
 from .performance import calculate_performance_metrics
-# Import monte_carlo functions
+
+# Import optional modules. If any are missing, raise an explicit error so that
+# tests fail instead of silently using placeholders.
 try:
     from .monte_carlo import generate_market_conditions, run_monte_carlo_simulation
-except ImportError as e:
-    import logging
-    logger = logging.getLogger(__name__)
-    logger.warning(f"Production dependency missing: {e}")
-    # Fallback implementation for generate_market_conditions
-    def generate_market_conditions(
-        years=10,
-        base_appreciation_rate=0.03,
-        appreciation_volatility=0.02,
-        base_default_rate=0.01,
-        default_volatility=0.005,
-        correlation=0.3,
-        seed=None
-    ):
-        """Fallback implementation for generate_market_conditions"""
-        market_conditions = {}
-        zones = ['green', 'orange', 'red']
-        zone_appreciation_modifiers = {'green': 0.8, 'orange': 1.0, 'red': 1.2}
-        zone_default_modifiers = {'green': 0.7, 'orange': 1.0, 'red': 1.5}
+except Exception as e:  # pragma: no cover - import-time failure
+    raise ImportError(
+        "Monte Carlo module is unavailable. Install required dependencies to use this feature."
+    ) from e
 
-        for year in range(years + 1):
-            year_str = str(year)
-            appreciation_rates_by_zone = {}
-            default_rates_by_zone = {}
-
-            for zone in zones:
-                appreciation_rates_by_zone[zone] = float(base_appreciation_rate * zone_appreciation_modifiers[zone])
-                default_rates_by_zone[zone] = float(base_default_rate * zone_default_modifiers[zone])
-
-            market_conditions[year_str] = {
-                'appreciation_rates': appreciation_rates_by_zone,
-                'default_rates': default_rates_by_zone,
-                'base_appreciation_rate': float(base_appreciation_rate),
-                'base_default_rate': float(base_default_rate),
-                'housing_market_trend': 'stable',
-                'interest_rate_environment': 'stable',
-                'economic_outlook': 'stable'
-            }
-
-        return market_conditions
-
-    def run_monte_carlo_simulation(*args, **kwargs):
-        return {'monte_carlo_results': 'mocked'}
 from .gp_entity import GPEntity
 from .multi_fund import MultiFundManager
 
-# Mock imports for testing
 try:
     from .optimization import optimize_portfolio
-except ImportError:
-    def optimize_portfolio(*args, **kwargs):
-        return {'optimization_result': 'mocked'}
+except Exception as e:  # pragma: no cover - import-time failure
+    raise ImportError(
+        "Optimization module is unavailable. Install required dependencies to use this feature."
+    ) from e
 
 try:
     from .stress_testing import generate_stress_scenarios, run_stress_test
-except ImportError:
-    def generate_stress_scenarios(*args, **kwargs):
-        return {'stress_scenarios': 'mocked'}
-    def run_stress_test(*args, **kwargs):
-        return {'stress_test_results': 'mocked'}
+except Exception as e:  # pragma: no cover - import-time failure
+    raise ImportError(
+        "Stress testing module is unavailable. Install required dependencies to use this feature."
+    ) from e
 
 try:
     from .reporting import generate_detailed_report
-except ImportError:
-    def generate_detailed_report(*args, **kwargs):
-        return {'report': 'mocked'}
+except Exception as e:  # pragma: no cover - import-time failure
+    raise ImportError(
+        "Reporting module is unavailable. Install required dependencies to use this feature."
+    ) from e
 
 try:
     from .external_data import MarketDataManager, generate_market_conditions_from_external_data
-except ImportError:
-    class MarketDataManager:
-        def __init__(self, *args, **kwargs):
-            pass
-    def generate_market_conditions_from_external_data(*args, **kwargs):
-        return {'market_conditions': 'mocked'}
+except Exception as e:  # pragma: no cover - import-time failure
+    raise ImportError(
+        "External data module is unavailable. Install required dependencies to use this feature."
+    ) from e
 
 # Set up logging
 logger = logging.getLogger(__name__)

--- a/tests/test_simulation_controller_imports.py
+++ b/tests/test_simulation_controller_imports.py
@@ -1,0 +1,13 @@
+import importlib
+import sys
+import pytest
+
+def test_import_fails_without_optional_dependencies(monkeypatch):
+    """SimulationController should raise ImportError when optional modules are missing."""
+    # Ensure numpy and pandas look missing so submodules fail to load
+    monkeypatch.setitem(sys.modules, 'numpy', None, raising=False)
+    monkeypatch.setitem(sys.modules, 'pandas', None, raising=False)
+    # Remove any cached modules
+    sys.modules.pop('src.backend.calculations.simulation_controller', None)
+    with pytest.raises(ImportError):
+        importlib.import_module('src.backend.calculations.simulation_controller')


### PR DESCRIPTION
## Summary
- eliminate stub implementations in `simulation_controller.py`
- add check that importing the controller fails cleanly if optional deps are absent

## Testing
- `pytest -q` *(fails: command not found)*