### PR TITLE
Add Monte Carlo and frontier visualizations

### DIFF
--- a/src/frontend/src/components/results/EfficientFrontierChart.tsx
+++ b/src/frontend/src/components/results/EfficientFrontierChart.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { ScatterChart, Scatter, XAxis, YAxis, Tooltip, CartesianGrid, ResponsiveContainer, Line } from 'recharts';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useEfficientFrontier } from '@/hooks/use-efficient-frontier';
+
+interface Props {
+  optimizationId: string;
+}
+
+export function EfficientFrontierChart({ optimizationId }: Props) {
+  const { data, isLoading } = useEfficientFrontier(optimizationId);
+
+  const points = data?.efficient_frontier || [];
+
+  if (isLoading) {
+    return <Skeleton className="w-full h-64" />;
+  }
+
+  return (
+    <div className="h-64">
+      {points.length > 0 ? (
+        <ResponsiveContainer width="100%" height="100%">
+          <ScatterChart margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+            <CartesianGrid />
+            <XAxis type="number" dataKey="risk" name="Risk" tickFormatter={(v) => `${(v * 100).toFixed(1)}%`} />
+            <YAxis type="number" dataKey="return" name="Return" tickFormatter={(v) => `${(v * 100).toFixed(1)}%`} />
+            <Tooltip formatter={(val: number) => `${(val * 100).toFixed(2)}%`} />
+            <Scatter data={points} fill="#3b82f6" />
+            <Line type="monotone" dataKey="return" data={points} stroke="#94a3b8" dot={false} />
+          </ScatterChart>
+        </ResponsiveContainer>
+      ) : (
+        <div className="flex items-center justify-center h-full text-muted-foreground">No frontier data</div>
+      )}
+    </div>
+  );
+}
+
+export default EfficientFrontierChart;

--- a/src/frontend/src/components/results/MonteCarloResults.tsx
+++ b/src/frontend/src/components/results/MonteCarloResults.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from 'recharts';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useMonteCarloResults } from '@/hooks/use-montecarlo-results';
+
+interface Props {
+  simulationId: string;
+  metric?: 'irr' | 'multiple' | 'default_rate';
+}
+
+export function MonteCarloResults({ simulationId, metric = 'irr' }: Props) {
+  const {
+    data: distribution,
+    isLoading: loadingDist
+  } = useMonteCarloResults(simulationId, 'distribution', metric);
+
+  const {
+    data: sensitivity,
+    isLoading: loadingSens
+  } = useMonteCarloResults(simulationId, 'sensitivity', metric);
+
+  const distChartData = React.useMemo(() => {
+    if (!distribution) return [];
+    const labels = distribution.data.labels || [];
+    const dataset = distribution.data.datasets?.[0];
+    return labels.map((label: number, idx: number) => ({
+      label,
+      value: dataset?.data?.[idx] ?? 0
+    }));
+  }, [distribution]);
+
+  const sensChartData = React.useMemo(() => {
+    if (!sensitivity) return [];
+    const labels = sensitivity.data.labels || [];
+    const dataset = sensitivity.data.datasets?.[0];
+    return labels.map((label: string, idx: number) => ({
+      label,
+      value: dataset?.data?.[idx] ?? 0
+    }));
+  }, [sensitivity]);
+
+  if (loadingDist && loadingSens) {
+    return <Skeleton className="w-full h-64" />;
+  }
+
+  return (
+    <div className="space-y-8">
+      <div className="h-64">
+        {distChartData.length > 0 ? (
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={distChartData} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="label" />
+              <YAxis />
+              <Tooltip />
+              <Bar dataKey="value" fill="#3b82f6" />
+            </BarChart>
+          </ResponsiveContainer>
+        ) : (
+          <div className="flex items-center justify-center h-full text-muted-foreground">No distribution data</div>
+        )}
+      </div>
+      <div className="h-64">
+        {sensChartData.length > 0 ? (
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart layout="vertical" data={sensChartData} margin={{ top: 20, right: 20, bottom: 20, left: 40 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis type="number" />
+              <YAxis type="category" dataKey="label" width={100} />
+              <Tooltip />
+              <Bar dataKey="value" fill="#22c55e" />
+            </BarChart>
+          </ResponsiveContainer>
+        ) : (
+          <div className="flex items-center justify-center h-full text-muted-foreground">No sensitivity data</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default MonteCarloResults;

--- a/src/frontend/src/hooks/index.ts
+++ b/src/frontend/src/hooks/index.ts
@@ -15,3 +15,5 @@ export * from './useChartData';
 export * from './useMetricsData';
 export * from './useSimulationStatus';
 export * from './useWindowSize';
+export * from './use-montecarlo-results';
+export * from './use-efficient-frontier';

--- a/src/frontend/src/hooks/use-efficient-frontier.ts
+++ b/src/frontend/src/hooks/use-efficient-frontier.ts
@@ -1,0 +1,12 @@
+import { useQuery } from 'react-query';
+import { useSimulationStore } from '@/store/simulation-store';
+
+export function useEfficientFrontier(optimizationId: string) {
+  const { getEfficientFrontier } = useSimulationStore();
+
+  return useQuery(
+    ['efficientFrontier', optimizationId],
+    () => getEfficientFrontier(optimizationId),
+    { enabled: !!optimizationId }
+  );
+}

--- a/src/frontend/src/hooks/use-montecarlo-results.ts
+++ b/src/frontend/src/hooks/use-montecarlo-results.ts
@@ -1,0 +1,16 @@
+import { useQuery } from 'react-query';
+import { useSimulationStore } from '@/store/simulation-store';
+
+export function useMonteCarloResults(
+  simulationId: string,
+  resultType: 'distribution' | 'sensitivity' | 'confidence' = 'distribution',
+  metric: 'irr' | 'multiple' | 'default_rate' = 'irr'
+) {
+  const { getMonteCarloResults } = useSimulationStore();
+
+  return useQuery(
+    ['monteCarlo', simulationId, resultType, metric],
+    () => getMonteCarloResults(simulationId, resultType, metric),
+    { enabled: !!simulationId }
+  );
+}

--- a/src/frontend/src/pages/results.tsx
+++ b/src/frontend/src/pages/results.tsx
@@ -51,6 +51,8 @@ import { GPIRRBreakdownChart } from '@/components/results/gp-irr-breakdown-chart
 import { EnhancedZoneAllocationChart } from '@/components/results/enhanced-zone-allocation-chart';
 import { LPEconomicsTab } from '@/components/results/lp-economics-tab';
 import { InvestmentJourneyVisualization } from '@/components/results/investment-journey-visualization';
+import { MonteCarloResults } from '@/components/results/MonteCarloResults';
+import { EfficientFrontierChart } from '@/components/results/EfficientFrontierChart';
 import { MetricCard } from '@/components/ui/metric-card';
 import { LogLevel, LogCategory, log, logBackendDataStructure } from '@/utils/logging';
 import { formatCurrency, formatPercentage, formatMultiple, formatDecimal, formatNumber } from '@/lib/formatters';
@@ -432,8 +434,13 @@ export function Results() {
         </TabsContent>
 
         {/* Advanced Tab */}
-        <TabsContent value="advanced" className="p-6">
-          <div className="text-muted-foreground">Advanced analytics coming soon.</div>
+        <TabsContent value="advanced" className="space-y-8 p-6">
+          {simulationId && (
+            <>
+              <MonteCarloResults simulationId={simulationId} />
+              <EfficientFrontierChart optimizationId={simulationId} />
+            </>
+          )}
         </TabsContent>
       </Tabs>
 

--- a/src/frontend/src/store/simulation-store.ts
+++ b/src/frontend/src/store/simulation-store.ts
@@ -22,6 +22,12 @@ interface SimulationState {
   runSimulation: (id: string) => Promise<void>;
   runSimulationWithConfig: (config: any) => Promise<any>;
   getSimulationResults: (id: string, timeGranularity?: 'yearly' | 'monthly') => Promise<any>;
+  getMonteCarloResults: (
+    id: string,
+    resultType?: 'distribution' | 'sensitivity' | 'confidence',
+    metricType?: 'irr' | 'multiple' | 'default_rate'
+  ) => Promise<any>;
+  getEfficientFrontier: (optimizationId: string) => Promise<any>;
   get100MPreset: () => any;
   clearCurrentSimulation: () => void;
 }
@@ -137,6 +143,41 @@ export const useSimulationStore = create<SimulationState>((set, get) => ({
       return results;
     } catch (error) {
       log(LogLevel.ERROR, LogCategory.STORE, `Error getting visualization for ${id}:`, { error });
+      throw error;
+    }
+  },
+
+  getMonteCarloResults: async (
+    id: string,
+    resultType: 'distribution' | 'sensitivity' | 'confidence' = 'distribution',
+    metricType: 'irr' | 'multiple' | 'default_rate' = 'irr'
+  ) => {
+    try {
+      log(
+        LogLevel.INFO,
+        LogCategory.STORE,
+        `Getting Monte Carlo results for ${id} type ${resultType}`
+      );
+      const data = await sdkWrapper.getMonteCarloResults(id, resultType, metricType);
+      return data;
+    } catch (error) {
+      log(LogLevel.ERROR, LogCategory.STORE, `Error getting Monte Carlo results for ${id}:`, { error });
+      throw error;
+    }
+  },
+
+  getEfficientFrontier: async (optimizationId: string) => {
+    try {
+      log(LogLevel.INFO, LogCategory.STORE, `Getting efficient frontier for ${optimizationId}`);
+      const data = await sdkWrapper.getEfficientFrontier(optimizationId);
+      return data;
+    } catch (error) {
+      log(
+        LogLevel.ERROR,
+        LogCategory.STORE,
+        `Error getting efficient frontier for ${optimizationId}:`,
+        { error }
+      );
       throw error;
     }
   },

--- a/src/frontend/src/utils/sdkWrapper.ts
+++ b/src/frontend/src/utils/sdkWrapper.ts
@@ -278,6 +278,41 @@ export const runSimulationWithConfig = async (config: any) => {
 };
 
 /**
+ * Get Monte Carlo visualization data
+ */
+export const getMonteCarloResults = async (
+  id: string,
+  resultType: string = 'distribution',
+  metricType: string = 'irr'
+) => {
+  try {
+    log(LogLevel.INFO, LogCategory.API, `Getting Monte Carlo results for ${id}`);
+    const response = await simulationSDK.getMonteCarloVisualization(id, resultType, metricType);
+    return response;
+  } catch (error) {
+    log(LogLevel.ERROR, LogCategory.API, `Error getting Monte Carlo results for ${id}:`, { error });
+    throw error;
+  }
+};
+
+/**
+ * Get efficient frontier data
+ */
+export const getEfficientFrontier = async (optimizationId: string) => {
+  try {
+    log(LogLevel.INFO, LogCategory.API, `Getting efficient frontier for ${optimizationId}`);
+    const resp = await fetch(`/api/optimization/${optimizationId}/efficient-frontier`);
+    if (!resp.ok) {
+      throw new Error('Failed to fetch frontier');
+    }
+    return await resp.json();
+  } catch (error) {
+    log(LogLevel.ERROR, LogCategory.API, `Error getting efficient frontier ${optimizationId}:`, { error });
+    throw error;
+  }
+};
+
+/**
  * Get the 100M preset configuration
  */
 export const get100MPreset = () => {
@@ -298,6 +333,8 @@ export const sdkWrapper = {
   runSimulation,
   getSimulationResults,
   getSimulationVisualization,
+  getMonteCarloResults,
+  getEfficientFrontier,
   runSimulationWithConfig,
   get100MPreset,
   setCacheEnabled,


### PR DESCRIPTION
## Summary
- implement `MonteCarloResults` and `EfficientFrontierChart` components
- add new hooks for fetching Monte Carlo and efficient frontier data
- extend Zustand store and SDK wrapper for new API calls
- show Monte Carlo and efficient frontier analytics in the Advanced tab

## Testing
- `npm --prefix src/frontend run lint` *(fails: ESLint couldn't find a configuration file)*