### PR TITLE
Add multi-fund & tranched simulation support

### DIFF
--- a/src/frontend/src/sdk/index.ts
+++ b/src/frontend/src/sdk/index.ts
@@ -2256,6 +2256,56 @@ export class SimulationSDK {
   }
 
   /**
+   * Create a multi-fund simulation
+   * @param payload Configuration payload for multiple funds
+   * @returns Aggregated simulation results
+   */
+  async createMultiFundSimulation(payload: any): Promise<any> {
+    try {
+      log(LogLevel.INFO, LogCategory.API, 'Creating multi-fund simulation');
+      const response = await apiClient.request({
+        method: 'POST',
+        url: '/api/multi-fund-simulations/',
+        body: transformApiRequest(payload),
+        mediaType: 'application/json'
+      });
+      return transformApiResponse(response);
+    } catch (error) {
+      log(
+        LogLevel.ERROR,
+        LogCategory.API,
+        `Error creating multi-fund simulation: ${error}`
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Create a tranched fund simulation
+   * @param payload Configuration payload defining the tranches
+   * @returns Aggregated simulation results
+   */
+  async createTranchedFundSimulation(payload: any): Promise<any> {
+    try {
+      log(LogLevel.INFO, LogCategory.API, 'Creating tranched fund simulation');
+      const response = await apiClient.request({
+        method: 'POST',
+        url: '/api/tranched-fund-simulations/',
+        body: transformApiRequest(payload),
+        mediaType: 'application/json'
+      });
+      return transformApiResponse(response);
+    } catch (error) {
+      log(
+        LogLevel.ERROR,
+        LogCategory.API,
+        `Error creating tranched fund simulation: ${error}`
+      );
+      throw error;
+    }
+  }
+
+  /**
    * Save a configuration
    * @param name Configuration name
    * @param description Configuration description

--- a/src/frontend/src/store/simulation-store.ts
+++ b/src/frontend/src/store/simulation-store.ts
@@ -15,12 +15,19 @@ interface SimulationState {
   isLoadingCurrentSimulation: boolean;
   currentSimulationError: Error | null;
 
+  // Aggregated results from multi-fund or tranched simulations
+  aggregatedResults: any | null;
+  isLoadingAggregatedResults: boolean;
+  aggregatedResultsError: Error | null;
+
   // Actions
   fetchSimulations: () => Promise<void>;
   fetchSimulation: (id: string, forceRefresh?: boolean) => Promise<void>;
   createSimulation: (config: any) => Promise<any>;
   runSimulation: (id: string) => Promise<void>;
   runSimulationWithConfig: (config: any) => Promise<any>;
+  createMultiFundSimulation: (payload: any) => Promise<any>;
+  createTranchedFundSimulation: (payload: any) => Promise<any>;
   getSimulationResults: (id: string, timeGranularity?: 'yearly' | 'monthly') => Promise<any>;
   get100MPreset: () => any;
   clearCurrentSimulation: () => void;
@@ -36,6 +43,10 @@ export const useSimulationStore = create<SimulationState>((set, get) => ({
   currentSimulation: null,
   isLoadingCurrentSimulation: false,
   currentSimulationError: null,
+
+  aggregatedResults: null,
+  isLoadingAggregatedResults: false,
+  aggregatedResultsError: null,
 
   // Actions
   fetchSimulations: async () => {
@@ -104,6 +115,40 @@ export const useSimulationStore = create<SimulationState>((set, get) => ({
       return result;
     } catch (error) {
       log(LogLevel.ERROR, LogCategory.STORE, 'Error running simulation with config:', { error });
+      throw error;
+    }
+  },
+
+  createMultiFundSimulation: async (payload: any) => {
+    try {
+      log(LogLevel.INFO, LogCategory.STORE, 'Creating multi-fund simulation');
+      set({ isLoadingAggregatedResults: true, aggregatedResultsError: null });
+      const result = await sdkWrapper.createMultiFundSimulation(payload);
+      set({ aggregatedResults: result, isLoadingAggregatedResults: false });
+      return result;
+    } catch (error) {
+      log(LogLevel.ERROR, LogCategory.STORE, 'Error creating multi-fund simulation:', { error });
+      set({
+        isLoadingAggregatedResults: false,
+        aggregatedResultsError: error instanceof Error ? error : new Error(String(error))
+      });
+      throw error;
+    }
+  },
+
+  createTranchedFundSimulation: async (payload: any) => {
+    try {
+      log(LogLevel.INFO, LogCategory.STORE, 'Creating tranched fund simulation');
+      set({ isLoadingAggregatedResults: true, aggregatedResultsError: null });
+      const result = await sdkWrapper.createTranchedFundSimulation(payload);
+      set({ aggregatedResults: result, isLoadingAggregatedResults: false });
+      return result;
+    } catch (error) {
+      log(LogLevel.ERROR, LogCategory.STORE, 'Error creating tranched fund simulation:', { error });
+      set({
+        isLoadingAggregatedResults: false,
+        aggregatedResultsError: error instanceof Error ? error : new Error(String(error))
+      });
       throw error;
     }
   },

--- a/src/frontend/src/utils/sdkWrapper.ts
+++ b/src/frontend/src/utils/sdkWrapper.ts
@@ -278,6 +278,32 @@ export const runSimulationWithConfig = async (config: any) => {
 };
 
 /**
+ * Create a multi-fund simulation
+ */
+export const createMultiFundSimulation = async (payload: any) => {
+  try {
+    const result = await simulationSDK.createMultiFundSimulation(payload);
+    return result;
+  } catch (error) {
+    log(LogLevel.ERROR, LogCategory.API, 'Error creating multi-fund simulation:', { error });
+    throw error;
+  }
+};
+
+/**
+ * Create a tranched fund simulation
+ */
+export const createTranchedFundSimulation = async (payload: any) => {
+  try {
+    const result = await simulationSDK.createTranchedFundSimulation(payload);
+    return result;
+  } catch (error) {
+    log(LogLevel.ERROR, LogCategory.API, 'Error creating tranched fund simulation:', { error });
+    throw error;
+  }
+};
+
+/**
  * Get the 100M preset configuration
  */
 export const get100MPreset = () => {
@@ -299,6 +325,8 @@ export const sdkWrapper = {
   getSimulationResults,
   getSimulationVisualization,
   runSimulationWithConfig,
+  createMultiFundSimulation,
+  createTranchedFundSimulation,
   get100MPreset,
   setCacheEnabled,
   isCacheEnabled,


### PR DESCRIPTION
## Summary
- expose new multi-fund/tranched simulation API calls in the SDK
- wrap them in `sdkWrapper`
- add Zustand store actions and state for aggregated results

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `./generate-sdk.sh` *(fails: EHOSTUNREACH while installing dependencies)*