### PR TITLE
Add fund aggregation components

### DIFF
--- a/docs/frontend/UI/UI_WORKFLOWS.md
+++ b/docs/frontend/UI/UI_WORKFLOWS.md
@@ -103,6 +103,22 @@ This document outlines the key user workflows for the Simulation Module UI and h
 - Percentile tables
 - Sensitivity analysis charts
 
+### 5. Multi-Fund Result Review
+
+**User Journey:**
+1. User runs or selects a simulation containing multiple funds or tranches
+2. System fetches aggregated results with fund-level and tranche-level metrics
+3. User reviews the aggregated metrics and tranche details
+4. User can drill down into individual fund results if needed
+
+**API Mapping:**
+1. GET `/api/simulations/{simulation_id}/results` to retrieve aggregated results
+
+**UI Components Needed:**
+- Fund aggregation summary card
+- Tranche details table
+- Links to individual fund results
+
 ## Secondary Workflows
 
 ### 1. Saving and Loading Configurations

--- a/src/frontend/src/components/results/fund-aggregation-summary.tsx
+++ b/src/frontend/src/components/results/fund-aggregation-summary.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { formatCurrency, formatPercentage } from '@/utils/formatters';
+
+interface FundAggregationSummaryProps {
+  aggregated: any | null;
+  isLoading?: boolean;
+}
+
+export function FundAggregationSummary({ aggregated, isLoading = false }: FundAggregationSummaryProps) {
+  const metrics = React.useMemo(() => {
+    if (!aggregated || isLoading) return null;
+    return {
+      totalFundSize: aggregated.total_fund_size ?? aggregated.totalFundSize ?? 0,
+      totalLoanCount: aggregated.total_loan_count ?? aggregated.totalLoanCount ?? 0,
+      weightedIrr: aggregated.weighted_irr ?? aggregated.weightedIrr ?? 0,
+      weightedMultiple: aggregated.weighted_multiple ?? aggregated.weightedMultiple ?? 0,
+      totalInvested: aggregated.total_invested ?? aggregated.totalInvested,
+      totalReturned: aggregated.total_returned ?? aggregated.totalReturned,
+    };
+  }, [aggregated, isLoading]);
+
+  if (isLoading) {
+    return (
+      <Card className="w-full">
+        <CardHeader>
+          <CardTitle>Aggregated Results</CardTitle>
+        </CardHeader>
+        <CardContent className="grid grid-cols-2 md:grid-cols-3 gap-4">
+          {Array(6).fill(0).map((_, i) => (
+            <Skeleton key={i} className="h-16" />
+          ))}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!metrics) {
+    return null;
+  }
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle>Aggregated Results</CardTitle>
+      </CardHeader>
+      <CardContent className="grid grid-cols-2 md:grid-cols-3 gap-4">
+        <div className="space-y-1">
+          <p className="text-sm text-muted-foreground">Total Fund Size</p>
+          <p className="text-lg font-semibold">{formatCurrency(metrics.totalFundSize)}</p>
+        </div>
+        <div className="space-y-1">
+          <p className="text-sm text-muted-foreground">Total Loans</p>
+          <p className="text-lg font-semibold">{metrics.totalLoanCount}</p>
+        </div>
+        <div className="space-y-1">
+          <p className="text-sm text-muted-foreground">Weighted IRR</p>
+          <p className="text-lg font-semibold">{formatPercentage(metrics.weightedIrr)}</p>
+        </div>
+        <div className="space-y-1">
+          <p className="text-sm text-muted-foreground">Weighted Multiple</p>
+          <p className="text-lg font-semibold">{metrics.weightedMultiple?.toFixed?.(2)}x</p>
+        </div>
+        {metrics.totalInvested !== undefined && (
+          <div className="space-y-1">
+            <p className="text-sm text-muted-foreground">Total Invested</p>
+            <p className="text-lg font-semibold">{formatCurrency(metrics.totalInvested)}</p>
+          </div>
+        )}
+        {metrics.totalReturned !== undefined && (
+          <div className="space-y-1">
+            <p className="text-sm text-muted-foreground">Total Returned</p>
+            <p className="text-lg font-semibold">{formatCurrency(metrics.totalReturned)}</p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/frontend/src/components/results/tranche-details-table.tsx
+++ b/src/frontend/src/components/results/tranche-details-table.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Skeleton } from '@/components/ui/skeleton';
+import { formatCurrency, formatPercentage } from '@/utils/formatters';
+
+interface TrancheDetailsTableProps {
+  tranches: Record<string, any> | null;
+  isLoading?: boolean;
+}
+
+export function TrancheDetailsTable({ tranches, isLoading = false }: TrancheDetailsTableProps) {
+  const trancheArray = React.useMemo(() => {
+    if (!tranches || isLoading) return [];
+    return Object.entries(tranches)
+      .filter(([key]) => key !== 'errors')
+      .map(([id, t]) => ({ id, ...(t as any) }));
+  }, [tranches, isLoading]);
+
+  if (isLoading) {
+    return (
+      <Card className="w-full">
+        <CardHeader>
+          <CardTitle>Tranche Details</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-32 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!trancheArray.length) {
+    return null;
+  }
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle>Tranche Details</CardTitle>
+      </CardHeader>
+      <CardContent className="overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="whitespace-nowrap">Tranche ID</TableHead>
+              <TableHead className="whitespace-nowrap">Size</TableHead>
+              <TableHead className="whitespace-nowrap">Deploy Start</TableHead>
+              <TableHead className="whitespace-nowrap">Deploy Period</TableHead>
+              <TableHead className="whitespace-nowrap">IRR</TableHead>
+              <TableHead className="whitespace-nowrap">Multiple</TableHead>
+              <TableHead className="whitespace-nowrap">Loans</TableHead>
+              {trancheArray.some(t => t.total_returned !== undefined) && (
+                <TableHead className="whitespace-nowrap">Total Returned</TableHead>
+              )}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {trancheArray.map((t) => (
+              <TableRow key={t.id}>
+                <TableCell>{t.id}</TableCell>
+                <TableCell>{formatCurrency(t.size)}</TableCell>
+                <TableCell>{t.deploy_start ?? t.deployStart}</TableCell>
+                <TableCell>{t.deploy_period ?? t.deployPeriod}</TableCell>
+                <TableCell>{formatPercentage(t.irr)}</TableCell>
+                <TableCell>{t.multiple?.toFixed?.(2)}x</TableCell>
+                <TableCell>{t.loan_count ?? t.loanCount}</TableCell>
+                {trancheArray.some(tr => tr.total_returned !== undefined) && (
+                  <TableCell>{formatCurrency(t.total_returned ?? t.totalReturned)}</TableCell>
+                )}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/frontend/src/pages/results.tsx
+++ b/src/frontend/src/pages/results.tsx
@@ -70,6 +70,8 @@ import {
 
 import { LoanDistributionCard } from '@/components/results/investment-journey/loan-distribution-card';
 import { TimelineEventCard } from '@/components/results/investment-journey/timeline-event-card';
+import { FundAggregationSummary } from '@/components/results/fund-aggregation-summary';
+import { TrancheDetailsTable } from '@/components/results/tranche-details-table';
 
 export function Results() {
   const { simulationId } = useParams<{ simulationId: string }>();
@@ -340,6 +342,15 @@ export function Results() {
           </Button>
         </div>
       </div>
+
+      {results?.aggregated && (
+        <FundAggregationSummary aggregated={results.aggregated} isLoading={isLoading} />
+      )}
+
+      {results?.aggregated?.tranches &&
+        Object.keys(results.aggregated.tranches).length > 0 && (
+          <TrancheDetailsTable tranches={results.aggregated.tranches} isLoading={isLoading} />
+        )}
 
       {/* Main tabs */}
       <div className="flex justify-between items-center mb-4">


### PR DESCRIPTION
## Summary
- display aggregated results with new fund/tranche components
- integrate aggregation views into results page
- document multi-fund result review workflow

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: missing script)*
- `pytest -k headless_backend_full -q` *(fails: command not found)*