### PR TITLE
Add deployment monthly granularity field

### DIFF
--- a/src/backend/openapi.yaml
+++ b/src/backend/openapi.yaml
@@ -1179,6 +1179,10 @@ components:
             include_charts: true
         leverage:
           $ref: '#/components/schemas/LeverageConfig'
+        deployment_monthly_granularity:
+          type: boolean
+          description: Use monthly granularity for deployment/exit
+          default: false
         time_granularity:
           type: string
           description: Time granularity for simulation (yearly or monthly)

--- a/src/backend/schemas/simulation_config_schema.json
+++ b/src/backend/schemas/simulation_config_schema.json
@@ -725,6 +725,11 @@
       "default": true,
       "description": "If true, all loans are forced to exit on or before the official fund term; if false, loans may mature beyond the term"
     },
+    "deployment_monthly_granularity": {
+      "type": "boolean",
+      "description": "Use monthly granularity for deployment/exit",
+      "default": false
+    },
     "geo_strategy": {
       "type": "string",
       "description": "Geographical allocation strategy for traffic-light zones / suburb IDs",

--- a/src/frontend/src/api/models/SimulationConfig.ts
+++ b/src/frontend/src/api/models/SimulationConfig.ts
@@ -188,6 +188,10 @@ export type SimulationConfig = {
     report_config?: Record<string, any>;
     leverage?: LeverageConfig;
     /**
+     * Use monthly granularity for deployment/exit
+     */
+    deployment_monthly_granularity?: boolean;
+    /**
      * Time granularity for simulation (yearly or monthly)
      */
     time_granularity?: SimulationConfig.time_granularity;


### PR DESCRIPTION
## Summary
- expose `deployment_monthly_granularity` option in backend schema
- document the field in `openapi.yaml`
- include the field in generated frontend SDK model

## Testing
- `npm run generate-sdk` *(fails: missing script)*
- `./generate-sdk.sh` *(fails: EHOSTUNREACH during npm install)*
- `pytest -k headless_backend_full -q` *(fails: pytest not found)*