### PR TITLE
Add efficient frontier options in wizard

### DIFF
--- a/docs/Auditapr24/simulation_config_schema.md
+++ b/docs/Auditapr24/simulation_config_schema.md
@@ -116,6 +116,8 @@ This document defines the authoritative schema for all simulation configuration 
 - `variation_factor` (*optional*, `float`): Parameter variation for MC. Default: `0.1`
 - `monte_carlo_seed` (*optional*, `int`): Random seed for MC. Default: `null`
 - `optimization_enabled` (*optional*, `bool`): Enable portfolio optimization. Default: `false`
+- `generate_efficient_frontier` (*optional*, `bool`): Generate efficient frontier during optimization. Default: `false`
+- `efficient_frontier_points` (*optional*, `int`): Number of points on the efficient frontier. Default: `50`
 - `stress_testing_enabled` (*optional*, `bool`): Enable stress testing. Default: `false`
 - `external_data_enabled` (*optional*, `bool`): Use external data. Default: `false`
 - `generate_reports` (*optional*, `bool`): Generate reports. Default: `true`

--- a/src/frontend/src/components/wizard/steps/advanced-step.tsx
+++ b/src/frontend/src/components/wizard/steps/advanced-step.tsx
@@ -349,6 +349,22 @@ export function AdvancedStep() {
             defaultValue={false}
           />
           <ParameterField
+            name="generate_efficient_frontier"
+            label="Generate Efficient Frontier"
+            tooltip="Generate efficient frontier during optimization"
+            type="switch"
+            defaultValue={false}
+          />
+          <ParameterField
+            name="efficient_frontier_points"
+            label="Efficient Frontier Points"
+            tooltip="Number of points for efficient frontier curve"
+            type="number"
+            min={1}
+            step={1}
+            defaultValue={50}
+          />
+          <ParameterField
             name="stress_testing_enabled"
             label="Enable Stress Testing"
             tooltip="Whether to enable stress testing"

--- a/src/frontend/src/schemas/simulation-schema.ts
+++ b/src/frontend/src/schemas/simulation-schema.ts
@@ -140,6 +140,12 @@ export const simulationSchema = z.object({
   variation_factor: z.number().min(0).max(1, "Variation factor must be between 0 and 1").default(0.1),
   monte_carlo_seed: z.number().int().nullable().default(null),
   optimization_enabled: z.boolean().default(false),
+  generate_efficient_frontier: z.boolean().default(false),
+  efficient_frontier_points: z
+    .number()
+    .int()
+    .min(1)
+    .default(50),
   stress_testing_enabled: z.boolean().default(false),
   external_data_enabled: z.boolean().default(false),
   generate_reports: z.boolean().default(true),
@@ -269,6 +275,8 @@ export const defaultSimulationConfig: SimulationConfig = {
   variation_factor: 0.1,
   monte_carlo_seed: null,
   optimization_enabled: false,
+  generate_efficient_frontier: false,
+  efficient_frontier_points: 50,
   stress_testing_enabled: false,
   external_data_enabled: false,
   generate_reports: true,
@@ -375,6 +383,8 @@ export const wizardSteps = [
       'variation_factor',
       'monte_carlo_seed',
       'optimization_enabled',
+      'generate_efficient_frontier',
+      'efficient_frontier_points',
       'stress_testing_enabled',
       'external_data_enabled',
       'generate_reports',


### PR DESCRIPTION
## Summary
- extend simulation schema with efficient frontier options
- expose new options in Advanced wizard step
- document fields in canonical schema docs

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `pytest -k "generate_efficient_frontier"` *(fails: command not found)*