### PR TITLE
Remove profit reinvestment param

### DIFF
--- a/docs/Auditapr24/simulation_config_schema.md
+++ b/docs/Auditapr24/simulation_config_schema.md
@@ -43,9 +43,7 @@ This document defines the authoritative schema for all simulation configuration 
 
 ## **4. Reinvestment and Exit**
 - `reinvestment_period` (*optional*, `int`): Years during which reinvestment is allowed. Default: `5`
-- `reinvestment_percentage` (*optional*, `float`): Fraction of exits to reinvest. Default: `0.0`
-- `reinvestment_rate` (*optional*, `float`): Alias for above. Default: `0.0`
-- `profit_reinvestment_percentage` (*optional*, `float`): For American waterfall. Default: `0.0`
+- `reinvestment_rate` (*optional*, `float`): Fraction of exits to reinvest. Default: `0.0`
 - `reinvestment_reserve_rate` (*optional*, `float`): Fraction of cash reserved for reinvestment. Default: `0.8`
 - `avg_loan_exit_year` (*optional*, `float`): Average exit year for loans. Default: `7`
 - `exit_year_std_dev` (*optional*, `float`): Std dev of exit year. Default: `1.5`

--- a/src/frontend/src/components/wizard/steps/reinvestment-step.tsx
+++ b/src/frontend/src/components/wizard/steps/reinvestment-step.tsx
@@ -37,16 +37,6 @@ export function ReinvestmentStep() {
             defaultValue={0.0}
           />
           <ParameterField
-            name="profit_reinvestment_percentage"
-            label="Profit Reinvestment Percentage"
-            tooltip="The percentage of profits to reinvest (for American waterfall)"
-            type="percentage"
-            min={0}
-            max={1}
-            step={0.01}
-            defaultValue={0.0}
-          />
-          <ParameterField
             name="reinvestment_reserve_rate"
             label="Reinvestment Reserve Rate"
             tooltip="The fraction of cash reserved for reinvestment"

--- a/src/frontend/src/components/wizard/steps/review-step.tsx
+++ b/src/frontend/src/components/wizard/steps/review-step.tsx
@@ -65,7 +65,6 @@ export function ReviewStep() {
           fields={[
             { name: 'reinvestment_period', label: 'Reinvestment Period', type: 'number' },
             { name: 'reinvestment_rate', label: 'Reinvestment Rate', type: 'percentage' },
-            { name: 'profit_reinvestment_percentage', label: 'Profit Reinvestment Percentage', type: 'percentage' },
             { name: 'reinvestment_reserve_rate', label: 'Reinvestment Reserve Rate', type: 'percentage' },
             { name: 'avg_loan_exit_year', label: 'Average Loan Exit Year', type: 'number' },
             { name: 'exit_year_std_dev', label: 'Exit Year Standard Deviation', type: 'number' },

--- a/src/frontend/src/schemas/simulation-schema.ts
+++ b/src/frontend/src/schemas/simulation-schema.ts
@@ -31,9 +31,7 @@ export const simulationSchema = z.object({
 
   // 4. Reinvestment and Exit
   reinvestment_period: z.number().int().min(0).max(20, "Reinvestment period must be between 0 and 20 years").default(5),
-  reinvestment_percentage: z.number().min(0).max(1, "Reinvestment percentage must be between 0% and 100%").default(0.0),
   reinvestment_rate: z.number().min(0).max(1, "Reinvestment rate must be between 0% and 100%").default(0.0),
-  profit_reinvestment_percentage: z.number().min(0).max(1, "Profit reinvestment percentage must be between 0% and 100%").default(0.0),
   reinvestment_reserve_rate: z.number().min(0).max(1, "Reinvestment reserve rate must be between 0% and 100%").default(0.8),
   avg_loan_exit_year: z.number().min(1).max(20, "Average loan exit year must be between 1 and 20").default(7),
   exit_year_std_dev: z.number().min(0).max(10, "Exit year standard deviation must be between 0 and 10").default(1.5),
@@ -196,9 +194,7 @@ export const defaultSimulationConfig: SimulationConfig = {
 
   // 4. Reinvestment and Exit
   reinvestment_period: 5,
-  reinvestment_percentage: 0.0,
   reinvestment_rate: 0.0,
-  profit_reinvestment_percentage: 0.0,
   reinvestment_reserve_rate: 0.8,
   avg_loan_exit_year: 7,
   exit_year_std_dev: 1.5,
@@ -326,8 +322,7 @@ export const wizardSteps = [
     title: 'Reinvestment & Exit',
     description: 'Configure reinvestment strategy and exit parameters',
     fields: [
-      'reinvestment_period', 'reinvestment_percentage', 'reinvestment_rate',
-      'profit_reinvestment_percentage', 'reinvestment_reserve_rate',
+      'reinvestment_period', 'reinvestment_rate', 'reinvestment_reserve_rate',
       'avg_loan_exit_year', 'exit_year_std_dev', 'early_exit_probability',
       'force_exit_within_fund_term',
     ],


### PR DESCRIPTION
## Summary
- drop `profit_reinvestment_percentage` field from the wizard schema and docs
- keep reinvestment parameters consistent (`reinvestment_rate`)

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*
- `npm test` *(fails: Missing script "test")*