### PR TITLE
Add variance analysis seed/distribution endpoints

### DIFF
--- a/src/backend/openapi.yaml
+++ b/src/backend/openapi.yaml
@@ -10,7 +10,7 @@ info:
     - Retrieving simulation results
     - Analyzing GP Entity economics
     - Real-time updates via WebSockets
-  version: 2.1.0
+  version: 2.2.0
   contact:
     name: Equihome Partners
 servers:
@@ -377,6 +377,85 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VarianceAnalysisResults'
+        '404':
+          description: Not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/simulations/{simulation_id}/variance-analysis/seeds:
+    get:
+      summary: Get Variance Analysis Seeds
+      description: Run Monte Carlo variance analysis and return individual seed results.
+      parameters:
+        - name: simulation_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: num_inner_simulations
+          in: query
+          description: Number of Monte Carlo repetitions to run
+          schema:
+            type: integer
+            default: 10
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        '404':
+          description: Not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/simulations/{simulation_id}/variance-analysis/distribution:
+    get:
+      summary: Get Variance Analysis Distribution
+      description: Run Monte Carlo variance analysis and return an IRR distribution histogram.
+      parameters:
+        - name: simulation_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: num_inner_simulations
+          in: query
+          description: Number of Monte Carlo repetitions to run
+          schema:
+            type: integer
+            default: 10
+        - name: bins
+          in: query
+          description: Number of histogram bins
+          schema:
+            type: integer
+            default: 20
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  bins:
+                    type: array
+                    items:
+                      type: number
+                  frequencies:
+                    type: array
+                    items:
+                      type: integer
         '404':
           description: Not found
         '422':

--- a/tests/test_variance_analysis.py
+++ b/tests/test_variance_analysis.py
@@ -35,3 +35,34 @@ def test_variance_analysis_endpoint():
     data = var_resp.json()
     assert "irr_percentiles" in data
     assert "var_percentiles" in data
+
+
+def test_variance_seed_results_endpoint():
+    resp = client.post("/api/simulations", json=FULL_CONFIG)
+    assert resp.status_code == 200, resp.text
+    sim_id = resp.json()["simulation_id"]
+    wait_for_completion(sim_id)
+
+    seeds_resp = client.get(
+        f"/api/simulations/{sim_id}/variance-analysis/seeds",
+        params={"num_inner_simulations": 2},
+    )
+    assert seeds_resp.status_code == 200, seeds_resp.text
+    seeds = seeds_resp.json()
+    assert isinstance(seeds, list)
+    assert len(seeds) == 2
+
+
+def test_variance_distribution_endpoint():
+    resp = client.post("/api/simulations", json=FULL_CONFIG)
+    assert resp.status_code == 200, resp.text
+    sim_id = resp.json()["simulation_id"]
+    wait_for_completion(sim_id)
+
+    dist_resp = client.get(
+        f"/api/simulations/{sim_id}/variance-analysis/distribution",
+        params={"num_inner_simulations": 2, "bins": 5},
+    )
+    assert dist_resp.status_code == 200, dist_resp.text
+    dist = dist_resp.json()
+    assert set(dist.keys()) == {"bins", "frequencies"}


### PR DESCRIPTION
## Summary
- add numpy import
- implement endpoints to expose per-seed and distribution data for variance analysis
- document new endpoints in OpenAPI spec and bump API version
- extend variance analysis tests for new routes

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `pip install pytest` *(fails: Could not find a version that satisfies the requirement pytest)*