### PR TITLE
Add variance analysis seed details option

### DIFF
--- a/src/backend/api/simulation_api.py
+++ b/src/backend/api/simulation_api.py
@@ -1968,7 +1968,8 @@ def calculate_reinvestments_from_cash_flows(cash_flows, years, avg_loan_size=250
 async def run_variance_analysis(
     simulation_id: str,
     num_inner_simulations: int = Query(10, ge=1, description="Number of Monte Carlo repetitions"),
-    include_seed_results: bool = Query(False, description="Include individual seed outcomes")
+    include_seed_results: bool = Query(False, description="Include individual seed outcomes"),
+    include_seed_details: bool = Query(False, description="Include cash flow and loan details for each seed"),
 ):
     """Run variance analysis for an existing simulation configuration."""
     if simulation_id not in simulation_results:
@@ -1979,13 +1980,19 @@ async def run_variance_analysis(
         raise HTTPException(status_code=404, detail="Simulation configuration missing")
 
     try:
-        aggregated, seeds = run_config_mc(config, num_inner_simulations)
+        aggregated, seeds = run_config_mc(
+            config,
+            num_inner_simulations,
+            collect_details=include_seed_details,
+        )
     except Exception as exc:
         logger.error("Variance analysis failed: %s", exc, exc_info=True)
         raise HTTPException(status_code=500, detail=str(exc))
 
     response = aggregated
-    if include_seed_results:
+    if include_seed_details:
+        response["seed_details"] = seeds
+    elif include_seed_results:
         response["seed_results"] = seeds
     return response
 

--- a/src/backend/openapi.yaml
+++ b/src/backend/openapi.yaml
@@ -370,6 +370,12 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: include_seed_details
+          in: query
+          description: Include full cash flow and loan details for each seed
+          schema:
+            type: boolean
+            default: false
       responses:
         '200':
           description: Successful Response
@@ -1715,6 +1721,20 @@ components:
             properties:
               seed: { type: integer }
               irr: { type: number }
+        seed_details:
+          type: array
+          items:
+            type: object
+            properties:
+              seed: { type: integer }
+              irr: { type: number }
+              cash_flows:
+                type: object
+                description: Cash flow table for the run
+              loans:
+                type: array
+                items:
+                  type: object
     ZoneMetrics:
       title: ZoneMetrics
       description: Traffic-Light metrics for a single suburb / zone.

--- a/tests/test_variance_analysis.py
+++ b/tests/test_variance_analysis.py
@@ -29,9 +29,11 @@ def test_variance_analysis_endpoint():
 
     var_resp = client.post(
         f"/api/simulations/{sim_id}/variance-analysis",
-        params={"num_inner_simulations": 2},
+        params={"num_inner_simulations": 2, "include_seed_details": True},
     )
     assert var_resp.status_code == 200, var_resp.text
     data = var_resp.json()
     assert "irr_percentiles" in data
     assert "var_percentiles" in data
+    assert "seed_details" in data
+    assert isinstance(data["seed_details"], list)


### PR DESCRIPTION
## Summary
- allow returning detailed loan/cash-flow data from variance analysis
- document new options in OpenAPI
- adjust endpoint and tests for `include_seed_details`

## Testing
- `bash generate-sdk.sh` *(fails: EHOSTUNREACH)*