### PR TITLE
Add iteration metrics and frontier detail APIs

### DIFF
--- a/src/backend/openapi.yaml
+++ b/src/backend/openapi.yaml
@@ -10,7 +10,7 @@ info:
     - Retrieving simulation results
     - Analyzing GP Entity economics
     - Real-time updates via WebSockets
-  version: 2.1.0
+  version: 2.3.0
   contact:
     name: Equihome Partners
 servers:
@@ -377,6 +377,165 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VarianceAnalysisResults'
+        '404':
+          description: Not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/simulations/{simulation_id}/variance-analysis/seeds:
+    get:
+      summary: Get Variance Analysis Seeds
+      description: Run Monte Carlo variance analysis and return individual seed results.
+      parameters:
+        - name: simulation_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: num_inner_simulations
+          in: query
+          description: Number of Monte Carlo repetitions to run
+          schema:
+            type: integer
+            default: 10
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        '404':
+          description: Not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/simulations/{simulation_id}/variance-analysis/distribution:
+    get:
+      summary: Get Variance Analysis Distribution
+      description: Run Monte Carlo variance analysis and return an IRR distribution histogram.
+      parameters:
+        - name: simulation_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: num_inner_simulations
+          in: query
+          description: Number of Monte Carlo repetitions to run
+          schema:
+            type: integer
+            default: 10
+        - name: bins
+          in: query
+          description: Number of histogram bins
+          schema:
+            type: integer
+            default: 20
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  bins:
+                    type: array
+                    items:
+                      type: number
+                  frequencies:
+                    type: array
+                    items:
+                      type: integer
+        '404':
+          description: Not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/simulations/{simulation_id}/variance-analysis/iterations:
+    get:
+      summary: Get Variance Iteration Metrics
+      description: Return metrics for each iteration of the inner Monte Carlo loop.
+      parameters:
+        - name: simulation_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: num_inner_simulations
+          in: query
+          description: Number of Monte Carlo repetitions to run
+          schema:
+            type: integer
+            default: 10
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 100
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        '404':
+          description: Not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/simulations/{simulation_id}/variance-analysis/var-table:
+    get:
+      summary: Get Variance Analysis VaR Table
+      description: Return Value-at-Risk metrics for specified confidence levels.
+      parameters:
+        - name: simulation_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: num_inner_simulations
+          in: query
+          description: Number of Monte Carlo repetitions to run
+          schema:
+            type: integer
+            default: 10
+        - name: confidence_levels
+          in: query
+          description: Comma-separated VaR confidence levels (0-1)
+          schema:
+            type: string
+            default: '0.95,0.99'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
         '404':
           description: Not found
         '422':
@@ -926,6 +1085,33 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EfficientFrontierResponse'
+        '404':
+          description: Not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/optimization/{optimization_id}/efficient-frontier/details:
+    get:
+      summary: Get Efficient Frontier Details
+      description: Return risk/return points with asset weights for each portfolio on the frontier.
+      parameters:
+        - name: optimization_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
         '404':
           description: Not found
         '422':

--- a/tests/test_variance_analysis.py
+++ b/tests/test_variance_analysis.py
@@ -35,3 +35,96 @@ def test_variance_analysis_endpoint():
     data = var_resp.json()
     assert "irr_percentiles" in data
     assert "var_percentiles" in data
+
+
+def test_variance_seed_results_endpoint():
+    resp = client.post("/api/simulations", json=FULL_CONFIG)
+    assert resp.status_code == 200, resp.text
+    sim_id = resp.json()["simulation_id"]
+    wait_for_completion(sim_id)
+
+    seeds_resp = client.get(
+        f"/api/simulations/{sim_id}/variance-analysis/seeds",
+        params={"num_inner_simulations": 2},
+    )
+    assert seeds_resp.status_code == 200, seeds_resp.text
+    seeds = seeds_resp.json()
+    assert isinstance(seeds, list)
+    assert len(seeds) == 2
+
+
+def test_variance_distribution_endpoint():
+    resp = client.post("/api/simulations", json=FULL_CONFIG)
+    assert resp.status_code == 200, resp.text
+    sim_id = resp.json()["simulation_id"]
+    wait_for_completion(sim_id)
+
+    dist_resp = client.get(
+        f"/api/simulations/{sim_id}/variance-analysis/distribution",
+        params={"num_inner_simulations": 2, "bins": 5},
+    )
+    assert dist_resp.status_code == 200, dist_resp.text
+    dist = dist_resp.json()
+    assert set(dist.keys()) == {"bins", "frequencies"}
+
+
+def test_variance_iteration_endpoint():
+    resp = client.post("/api/simulations", json=FULL_CONFIG)
+    assert resp.status_code == 200, resp.text
+    sim_id = resp.json()["simulation_id"]
+    wait_for_completion(sim_id)
+
+    iter_resp = client.get(
+        f"/api/simulations/{sim_id}/variance-analysis/iterations",
+        params={"num_inner_simulations": 2, "limit": 1},
+    )
+    assert iter_resp.status_code == 200, iter_resp.text
+    iterations = iter_resp.json()
+    assert isinstance(iterations, list)
+    assert len(iterations) == 1
+
+
+def test_variance_var_table_endpoint():
+    resp = client.post("/api/simulations", json=FULL_CONFIG)
+    assert resp.status_code == 200, resp.text
+    sim_id = resp.json()["simulation_id"]
+    wait_for_completion(sim_id)
+
+    var_resp = client.get(
+        f"/api/simulations/{sim_id}/variance-analysis/var-table",
+        params={"num_inner_simulations": 2, "confidence_levels": "0.9"},
+    )
+    assert var_resp.status_code == 200, var_resp.text
+    table = var_resp.json()
+    assert "value_at_risk" in table
+
+
+def test_efficient_frontier_details_endpoint():
+    resp = client.post("/api/simulations", json=FULL_CONFIG)
+    assert resp.status_code == 200, resp.text
+    sim_id = resp.json()["simulation_id"]
+    wait_for_completion(sim_id)
+
+    opt_resp = client.post(
+        "/api/optimization",
+        json={"risk_free_rate": 0.02, "generate_efficient_frontier": True},
+    )
+    assert opt_resp.status_code == 200, opt_resp.text
+    opt_id = opt_resp.json()["optimization_id"]
+    # Wait for completion
+    deadline = time.time() + 30
+    while True:
+        status = client.get(f"/api/optimization/{opt_id}/status")
+        assert status.status_code == 200, status.text
+        if status.json()["status"] == "completed":
+            break
+        if time.time() > deadline:
+            raise TimeoutError("Optimization did not complete")
+        time.sleep(0.5)
+
+    details_resp = client.get(
+        f"/api/optimization/{opt_id}/efficient-frontier/details"
+    )
+    assert details_resp.status_code == 200, details_resp.text
+    details = details_resp.json()
+    assert isinstance(details, list)


### PR DESCRIPTION
## Summary
- expose iteration-level Monte Carlo metrics and VaR table endpoints
- add efficient frontier detail route
- document new API routes and bump spec version to 2.3.0
- extend variance analysis tests for new endpoints

## Testing
- `./generate-sdk.sh` *(fails: connect EHOSTUNREACH)*
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `pip install pytest` *(fails: No route to host)*